### PR TITLE
Use an environmental variable for PyPI token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,5 +21,6 @@ jobs:
     # Build.
     - run: poetry build
     # Release.
-    - run: poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
     - run: poetry publish
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
The token is not leaked, since GitHub Actions redacts secrets from logs automatically. But it's safer to not rely on that.