### PR TITLE
Raising `ValueError` if matcher format is interrupted by end of string

### DIFF
--- a/logot/_match.py
+++ b/logot/_match.py
@@ -38,7 +38,7 @@ def _compile_replace(match: re.Match[str]) -> str:
     try:
         return _CONVERSION_MAP[match.group(1)]
     except KeyError:
-        raise ValueError(f"Unsupported format: {match.group(1)!r}") from None
+        raise ValueError(f"Unsupported format character {match.group(1)!r} at index {match.start(1)}") from None
 
 
 def compile(pattern: str) -> re.Pattern[str]:

--- a/logot/_match.py
+++ b/logot/_match.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 # Regex matching a simplified conversion specifier.
-_RE_CONVERSION = re.compile(r"%(.)")
+_RE_CONVERSION = re.compile(r"%(.|$)")
 
 # Mapping of conversion types to regex matchers.
 _CONVERSION_INT = r"\-?\d+"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -56,3 +56,9 @@ def test_unsupported_format() -> None:
     with pytest.raises(ValueError) as ex:
         compile("%b")
     assert str(ex.value) == "Unsupported format: 'b'"
+
+
+def test_truncated_format() -> None:
+    with pytest.raises(ValueError) as ex:
+        compile("%")
+    assert str(ex.value) == "Unsupported format: ''"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -55,10 +55,10 @@ def test_percent_matches() -> None:
 def test_unsupported_format() -> None:
     with pytest.raises(ValueError) as ex:
         compile("%b")
-    assert str(ex.value) == "Unsupported format: 'b'"
+    assert str(ex.value) == "Unsupported format character 'b' at index 1"
 
 
 def test_truncated_format() -> None:
     with pytest.raises(ValueError) as ex:
         compile("%")
-    assert str(ex.value) == "Unsupported format: ''"
+    assert str(ex.value) == "Unsupported format character '' at index 1"


### PR DESCRIPTION
Also added the index of the unsupported format character to the `ValueError` message.