### PR TITLE
Making `Logot._reduce()` fully thread-safe

### DIFF
--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -189,8 +189,12 @@ class Logot:
     def _reduce(self, log: Logged | None) -> Logged | None:
         # Drain the queue until the log is fully reduced.
         # This does not need a lock, since `deque.popleft()` is thread-safe.
-        while self._queue and log is not None:
-            log = log._reduce(self._queue.popleft())
+        while log is not None:
+            try:
+                record = self._queue.popleft()
+            except IndexError:
+                break
+            log = log._reduce(record)
         # All done!
         return log
 


### PR DESCRIPTION
Although there was no risk of data corruption, there was a theoretical risk of a race condition leading to an `IndexError` if multiple threads used `assert_logged()` or `assert_not_logged()` at the same.

This is not a plausible use-case, but it's nice to be fully thread safe.