### PR TITLE
Combining all coverage from `test` in a single required `report` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     # Fail if any needed jobs fail.
     # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
     - run: exit 1
-      if: needs.test.result != "success" || needs.docs.result != "success"
+      if: ${{ needs.test.result != "success" || needs.docs.result != "success" }}
     # Download coverage.
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
     # Run tests.
     - run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
-    - uses: actions/upload-artifact@v4
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-${{ matrix.python-version }}
         path: .coverage-${{ matrix.python-version }}
@@ -67,11 +68,6 @@ jobs:
     if: always()
     steps:
     - uses: actions/checkout@v4
-    # Download coverage.
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: coverage-*
-        merge-multiple: true
     # Install toolchain.
     - run: pipx install poetry
     - uses: actions/setup-python@v5
@@ -81,6 +77,11 @@ jobs:
     # Install dependencies.
     - run: poetry install
     # Report coverage.
+    - name: Download coverage
+      uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-*
+        merge-multiple: true
     - name: Combine coverage
       run: poetry run coverage combine .coverage-*
     - name: Report coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,8 @@ jobs:
     # Report coverage.
     - run: poetry run coverage combine .coverage-*
     - run: poetry run coverage report
-    # Fail if any previous jobs failed.
-    # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
+    # Fail if any `needs` job was not a success.
+    # Along with `if: always()`, this allows this job to act as a single required status check for the entire workflow.
     - name: Fail on previous error
       run: exit 1
       if: needs.test.result != 'success' || needs.docs.result != 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       with:
         pattern: coverage-*
         merge-multiple: true
+    - run: ls -a
     # Install toolchain.
     - run: pipx install poetry
     - uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - run: poetry run ruff format --check
     - run: poetry run mypy
     # Run tests.
-    - name: Run pytest
+    - name: Run tests
       run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
     - name: Upload coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     # Fail if any needed jobs fail.
     # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
     - run: exit 1
-    - if: needs.test.result != "success" || needs.docs.result != "success"
+      if: needs.test.result != "success" || needs.docs.result != "success"
     # Download coverage.
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,16 +67,11 @@ jobs:
     if: always()
     steps:
     - uses: actions/checkout@v4
-    # Fail if any needed jobs fail.
-    # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
-    - run: exit 1
-      if: needs.test.result != 'success' || needs.docs.result != 'success'
     # Download coverage.
     - uses: actions/download-artifact@v4
       with:
         pattern: coverage-*
         merge-multiple: true
-    - run: ls -a
     # Install toolchain.
     - run: pipx install poetry
     - uses: actions/setup-python@v5
@@ -86,5 +81,10 @@ jobs:
     # Install dependencies.
     - run: poetry install
     # Report coverage.
-    - run: poetry run coverage combine
+    - run: poetry run coverage combine .coverage-*
     - run: poetry run coverage report
+    # Fail if any previous jobs failed.
+    # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
+    - name: Fail on previous error
+      run: exit 1
+      if: needs.test.result != 'success' || needs.docs.result != 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,18 @@ jobs:
     needs:
     - test
     - docs
+    if: always()
     steps:
     - uses: actions/checkout@v4
+    # Fail if any needed jobs fail.
+    # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
+    - run: exit 1
+    - if: needs.test.result != "success" || needs.docs.result != "success"
+    # Download coverage.
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-*
+        merge-multiple: true
     # Install toolchain.
     - run: pipx install poetry
     - uses: actions/setup-python@v5
@@ -74,11 +84,6 @@ jobs:
         cache: poetry
     # Install dependencies.
     - run: poetry install
-    # Download coverage.
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: coverage-*
-        merge-multiple: true
     # Report coverage.
-    - run: coverage combine
-    - run: coverage report
+    - run: poetry run coverage combine
+    - run: poetry run coverage report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,6 @@ jobs:
       run: poetry run coverage report
     # Fail if any `needs` job was not a success.
     # Along with `if: always()`, this allows this job to act as a single required status check for the entire workflow.
-    - name: Fail on workflow error
+    - name: Fail if workflow error
       run: exit 1
       if: needs.test.result != 'success' || needs.docs.result != 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,13 @@ jobs:
     - run: poetry run ruff format --check
     - run: poetry run mypy
     # Run tests.
-    - run: poetry run coverage run -m pytest
-    - run: poetry run coverage report
+    - run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
+    # Upload coverage.
+    - uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage-${{ matrix.python-version }}
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -53,3 +58,27 @@ jobs:
     - run: poetry install --without dev --with docs
     # Build docs.
     - run: poetry run sphinx-build -W docs docs/_build
+
+  report:
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    - docs
+    steps:
+    - uses: actions/checkout@v4
+    # Install toolchain.
+    - run: pipx install poetry
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+        cache: poetry
+    # Install dependencies.
+    - run: poetry install
+    # Download coverage.
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: coverage-*
+        merge-multiple: true
+    # Report coverage.
+    - run: coverage combine
+    - run: coverage report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     - run: poetry run mypy
     # Run tests.
     - name: Run pytest
-    - run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
+      run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
     - name: Upload coverage
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     # Fail if any needed jobs fail.
     # This, along with `if: always()`, allows this job to act as the single required status check for the workflow.
     - run: exit 1
-      if: ${{ needs.test.result != "success" || needs.docs.result != "success" }}
+      if: needs.test.result != 'success' || needs.docs.result != 'success'
     # Download coverage.
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,10 +81,12 @@ jobs:
     # Install dependencies.
     - run: poetry install
     # Report coverage.
-    - run: poetry run coverage combine .coverage-*
-    - run: poetry run coverage report
+    - name: Combine coverage
+      run: poetry run coverage combine .coverage-*
+    - name: Report coverage
+      run: poetry run coverage report
     # Fail if any `needs` job was not a success.
     # Along with `if: always()`, this allows this job to act as a single required status check for the entire workflow.
-    - name: Fail on previous error
+    - name: Fail on workflow error
       run: exit 1
       if: needs.test.result != 'success' || needs.docs.result != 'success'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
     - run: poetry run ruff format --check
     - run: poetry run mypy
     # Run tests.
+    - name: Run pytest
     - run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
     - name: Upload coverage
@@ -58,7 +59,8 @@ jobs:
     # Install dependencies.
     - run: poetry install --without dev --with docs
     # Build docs.
-    - run: poetry run sphinx-build -W docs docs/_build
+    - name: Build docs
+      run: poetry run sphinx-build -W docs docs/_build
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: poetry
-    # Install dependencies.
+    # Run pre-install checks.
     - run: poetry check
     - run: poetry check --lock
     - run: poetry run python --version
-    - run: poetry install
+    # Install dependencies.
+    - name: Install dependencies
+      run: poetry install
     # Run checks.
     - run: poetry run ruff check
     - run: poetry run ruff format --check
@@ -57,7 +59,8 @@ jobs:
         python-version: "3.x"
         cache: poetry
     # Install dependencies.
-    - run: poetry install --without dev --with docs
+    - name: Install dependencies
+      run: poetry install --without dev --with docs
     # Build docs.
     - name: Build docs
       run: poetry run sphinx-build -W docs docs/_build
@@ -77,7 +80,8 @@ jobs:
         python-version: "3.x"
         cache: poetry
     # Install dependencies.
-    - run: poetry install
+    - name: Install dependencies
+      run: poetry install
     # Report coverage.
     - name: Download coverage
       uses: actions/download-artifact@v4


### PR DESCRIPTION
This allows us to have a single required job for the whole `build` workflow, rather than juggling marking all matrix jobs as required, which will get tedious when we test against multiple dependency versions.

It also means we can test the combined coverage, which will be useful if we get version-specific code paths.

Also put some effort into naming job steps nicely. ❤️ 