### PR TITLE
Allowing unknown `int` log levels

### DIFF
--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -6,8 +6,6 @@ import logging
 def validate_levelno(level: int | str) -> int:
     # Handle `int` level.
     if isinstance(level, int):
-        if logging.getLevelName(level).startswith("Level "):
-            raise ValueError(f"Unknown level: {level!r}")
         return level
     # Handle `str` level.
     if isinstance(level, str):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -13,12 +13,6 @@ def test_validate_levelno_int_pass() -> None:
     assert validate_levelno(logging.INFO) == logging.INFO
 
 
-def test_validate_levelno_int_fail() -> None:
-    with pytest.raises(ValueError) as ex:
-        validate_levelno(9999)
-    assert str(ex.value) == "Unknown level: 9999"
-
-
 def test_validate_levelno_str_pass() -> None:
     assert validate_levelno("INFO") == logging.INFO
 


### PR DESCRIPTION
Although it's neat to validate all `int` log levels are registered with the `logging` module, this falls flat for 3rd party logging frameworks (e.g. `loguru`, see #28)