### PR TITLE
Using `nitpicky` mode when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,3 +29,5 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
 }
+
+nitpicky = True


### PR DESCRIPTION
This will fail the build if any references are broken.