### PR TITLE
Log level matching refactor

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,9 +41,11 @@ Import the :mod:`logot` API in your tests:
 
 .. autoclass:: logot.Captured
 
-   .. autoattribute:: levelno
+   .. autoattribute:: levelname
 
    .. autoattribute:: msg
+
+   .. autoattribute:: levelno
 
 
 :mod:`logot.logged`

--- a/docs/captured.rst
+++ b/docs/captured.rst
@@ -48,7 +48,7 @@ Any 3rd-party logging library can be integrated with :mod:`logot` by sending :cl
 .. code:: python
 
    def on_foo_log(logot: Logot, record: FooRecord) -> None:
-      logot.capture(Captured(record.levelno, record.msg))
+      logot.capture(Captured(record.levelname, record.msg, levelno=record.levelno))
 
    foo_logger.add_handler(on_foo_log)
 

--- a/logot/_captured.py
+++ b/logot/_captured.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import logging
-from typing import Final
-
 from logot._format import format_log
-from logot._validate import validate_levelno
 
 
 class Captured:
@@ -23,31 +19,43 @@ class Captured:
 
         See :ref:`captured-3rd-party` usage guide.
 
-    :param level: The log level (e.g. :data:`logging.DEBUG`) or string name (e.g. ``"DEBUG"``).
+    :param levelname: The log level name (e.g. ``"DEBUG"``).
     :param msg: The log message.
+    :param levelno: The log level number.
     """
 
-    __slots__ = ("levelno", "msg")
+    __slots__ = ("levelname", "msg", "levelno")
 
-    levelno: Final[int]
+    levelname: str
     """
-    The integer log level (e.g. :data:`logging.DEBUG`).
+    The log level name (e.g. ``"DEBUG"``).
     """
 
-    msg: Final[str]
+    msg: str
     """
     The log message.
     """
 
-    def __init__(self, level: int | str, msg: str) -> None:
-        self.levelno = validate_levelno(level)
+    levelno: int
+    """
+    The log level number.
+    """
+
+    def __init__(self, levelname: str, msg: str, *, levelno: int) -> None:
+        self.levelname = levelname
         self.msg = msg
+        self.levelno = levelno
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, Captured) and other.levelno == self.levelno and other.msg == self.msg
+        return (
+            isinstance(other, Captured)
+            and other.levelname == self.levelname
+            and other.msg == self.msg
+            and other.levelno == self.levelno
+        )
 
     def __repr__(self) -> str:
-        return f"Captured({logging.getLevelName(self.levelno)!r}, {self.msg!r})"
+        return f"Captured({self.levelname!r}, {self.msg!r}, levelno={self.levelno!r})"
 
     def __str__(self) -> str:
-        return format_log(self.levelno, self.msg)
+        return format_log(self.levelname, self.msg)

--- a/logot/_captured.py
+++ b/logot/_captured.py
@@ -21,7 +21,7 @@ class Captured:
 
     :param levelname: The log level name (e.g. ``"DEBUG"``).
     :param msg: The log message.
-    :param levelno: The log level number.
+    :param levelno: The log level number (e.g. :data:`logging.DEBUG`).
     """
 
     __slots__ = ("levelname", "msg", "levelno")
@@ -38,7 +38,7 @@ class Captured:
 
     levelno: int
     """
-    The log level number.
+    The log level number (e.g. :data:`logging.DEBUG`).
     """
 
     def __init__(self, levelname: str, msg: str, *, levelno: int) -> None:

--- a/logot/_format.py
+++ b/logot/_format.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+import logging
+
+
+def format_level(level: str | int) -> str:
+    # Format `str` level.
+    if isinstance(level, str):
+        return level
+    # Format `int` level.
+    level: str = logging.getLevelName(level)
+    return level
+
 
 def format_log(levelname: str, msg: str) -> str:
     return f"[{levelname}] {msg}"

--- a/logot/_format.py
+++ b/logot/_format.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
 
-
-def format_log(levelno: int, msg: str) -> str:
-    return f"[{logging.getLevelName(levelno)}] {msg}"
+def format_log(levelname: str, msg: str) -> str:
+    return f"[{levelname}] {msg}"

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -128,6 +128,7 @@ class _RecordLogged(Logged):
         return f"log({self._level!r}, {self._msg!r})"
 
     def _reduce(self, captured: Captured) -> Logged | None:
+        print((self, captured))
         # Match `str` level.
         if isinstance(self._level, str):
             if self._level != captured.levelname:
@@ -139,7 +140,7 @@ class _RecordLogged(Logged):
         if not self._matcher(captured.msg):
             return self
         # We matched!
-        return self
+        return None
 
     def _str(self, *, indent: str) -> str:
         # Format `str` level.

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC, abstractmethod
 
 from logot._captured import Captured
-from logot._format import format_log
+from logot._format import format_level, format_log
 from logot._match import compile_matcher
 from logot._validate import validate_level
 
@@ -143,14 +142,7 @@ class _RecordLogged(Logged):
         return None
 
     def _str(self, *, indent: str) -> str:
-        # Format `str` level.
-        if isinstance(self._level, str):
-            levelname = self._level
-        # Format `int` level.
-        else:
-            levelname = logging.getLevelName(self._level)
-        # Format log.
-        return format_log(levelname, self._msg)
+        return format_log(format_level(self._level), self._msg)
 
 
 class _ComposedLogged(Logged):

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -128,13 +128,13 @@ class _RecordLogged(Logged):
         return f"log({self._level!r}, {self._msg!r})"
 
     def _reduce(self, captured: Captured) -> Logged | None:
-        # Match level.
+        # Match `str` level.
         if isinstance(self._level, str):
             if self._level != captured.levelname:
                 return self
-        else:
-            if self._level != captured.levelno:
-                return self
+        # Match `int` level.
+        elif self._level != captured.levelno:
+            return self
         # Match message.
         if not self._matcher(captured.msg):
             return self
@@ -142,10 +142,13 @@ class _RecordLogged(Logged):
         return self
 
     def _str(self, *, indent: str) -> str:
+        # Format `str` level.
         if isinstance(self._level, str):
             levelname = self._level
+        # Format `int` level.
         else:
             levelname = logging.getLevelName(self._level)
+        # Format log.
         return format_log(levelname, self._msg)
 
 

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -127,7 +127,6 @@ class _RecordLogged(Logged):
         return f"log({self._level!r}, {self._msg!r})"
 
     def _reduce(self, captured: Captured) -> Logged | None:
-        print((self, captured))
         # Match `str` level.
         if isinstance(self._level, str):
             if self._level != captured.levelname:

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from logot._captured import Captured
 from logot._format import format_log
 from logot._match import compile_matcher
-from logot._validate import validate_levelno
+from logot._validate import validate_level
 
 
 class Logged(ABC):
@@ -58,14 +58,14 @@ class Logged(ABC):
         raise NotImplementedError
 
 
-def log(level: int | str, msg: str) -> Logged:
+def log(level: str | int, msg: str) -> Logged:
     """
     Creates a :doc:`log pattern <logged>` representing a log record at the given ``level`` with the given ``msg``.
 
-    :param level: A log level (e.g. :data:`logging.DEBUG`) or string name (e.g. ``"DEBUG"``).
+    :param level: A log level name (e.g. ``"DEBUG"``) or numeric constant (e.g. :data:`logging.DEBUG`).
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(validate_levelno(level), msg)
+    return _RecordLogged(validate_level(level), msg)
 
 
 def debug(msg: str) -> Logged:
@@ -74,7 +74,7 @@ def debug(msg: str) -> Logged:
 
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(logging.DEBUG, msg)
+    return _RecordLogged("DEBUG", msg)
 
 
 def info(msg: str) -> Logged:
@@ -83,7 +83,7 @@ def info(msg: str) -> Logged:
 
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(logging.INFO, msg)
+    return _RecordLogged("INFO", msg)
 
 
 def warning(msg: str) -> Logged:
@@ -92,7 +92,7 @@ def warning(msg: str) -> Logged:
 
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(logging.WARNING, msg)
+    return _RecordLogged("WARNING", msg)
 
 
 def error(msg: str) -> Logged:
@@ -101,7 +101,7 @@ def error(msg: str) -> Logged:
 
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(logging.ERROR, msg)
+    return _RecordLogged("ERROR", msg)
 
 
 def critical(msg: str) -> Logged:
@@ -110,30 +110,43 @@ def critical(msg: str) -> Logged:
 
     :param msg: A log :doc:`message pattern <match>`.
     """
-    return _RecordLogged(logging.CRITICAL, msg)
+    return _RecordLogged("CRITICAL", msg)
 
 
 class _RecordLogged(Logged):
-    __slots__ = ("_levelno", "_msg", "_matcher")
+    __slots__ = ("_level", "_msg", "_matcher")
 
-    def __init__(self, levelno: int, msg: str) -> None:
-        self._levelno = levelno
+    def __init__(self, level: str | int, msg: str) -> None:
+        self._level = level
         self._msg = msg
         self._matcher = compile_matcher(msg)
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, _RecordLogged) and other._levelno == self._levelno and other._msg == self._msg
+        return isinstance(other, _RecordLogged) and other._level == self._level and other._msg == self._msg
 
     def __repr__(self) -> str:
-        return f"log({logging.getLevelName(self._levelno)!r}, {self._msg!r})"
+        return f"log({self._level!r}, {self._msg!r})"
 
     def _reduce(self, captured: Captured) -> Logged | None:
-        if self._levelno == captured.levelno and self._matcher(captured.msg):
-            return None
+        # Match level.
+        if isinstance(self._level, str):
+            if self._level != captured.levelname:
+                return self
+        else:
+            if self._level != captured.levelno:
+                return self
+        # Match message.
+        if not self._matcher(captured.msg):
+            return self
+        # We matched!
         return self
 
     def _str(self, *, indent: str) -> str:
-        return format_log(self._levelno, self._msg)
+        if isinstance(self._level, str):
+            levelname = self._level
+        else:
+            levelname = logging.getLevelName(self._level)
+        return format_log(levelname, self._msg)
 
 
 class _ComposedLogged(Logged):

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -34,7 +34,7 @@ class Logot:
     The default ``level`` used by :meth:`capturing`.
     """
 
-    DEFAULT_LOGGER: ClassVar[logging.Logger | str | None] = "root"
+    DEFAULT_LOGGER: ClassVar[logging.Logger | str | None] = None
     """
     The default ``logger`` used by :meth:`capturing`.
     """

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -9,7 +9,7 @@ from typing import ClassVar, TypeVar
 
 from logot._captured import Captured
 from logot._logged import Logged
-from logot._validate import validate_levelno, validate_logger, validate_timeout
+from logot._validate import validate_level, validate_logger, validate_timeout
 from logot._waiter import AsyncWaiter, SyncWaiter, Waiter
 
 W = TypeVar("W", bound=Waiter)
@@ -29,18 +29,14 @@ class Logot:
 
     __slots__ = ("_timeout", "_lock", "_queue", "_waiter")
 
-    DEFAULT_LEVEL: ClassVar[int | str] = logging.NOTSET
+    DEFAULT_LEVEL: ClassVar[str | int] = "DEBUG"
     """
     The default ``level`` used by :meth:`capturing`.
-
-    This is :data:`logging.NOTSET`, specifying that all logs are captured.
     """
 
-    DEFAULT_LOGGER: ClassVar[logging.Logger | str | None] = None
+    DEFAULT_LOGGER: ClassVar[logging.Logger | str | None] = "root"
     """
     The default ``logger`` used by :meth:`capturing`.
-
-    This is the root logger.
     """
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
@@ -63,7 +59,7 @@ class Logot:
     def capturing(
         self,
         *,
-        level: int | str = DEFAULT_LEVEL,
+        level: str | int = DEFAULT_LEVEL,
         logger: logging.Logger | str | None = DEFAULT_LOGGER,
     ) -> AbstractContextManager[Logot]:
         """
@@ -76,13 +72,13 @@ class Logot:
 
             See :doc:`captured` usage guide.
 
-        :param level: A log level (e.g. :data:`logging.DEBUG`) or string name (e.g. ``"DEBUG"``). Defaults to
+        :param level: A log level name (e.g. ``"DEBUG"``) or numeric constant (e.g. :data:`logging.DEBUG`). Defaults to
             :data:`logging.NOTSET`, specifying that all logs are captured.
         :param logger: A logger or logger name to capture logs from. Defaults to the root logger.
         """
-        levelno = validate_levelno(level)
+        level = validate_level(level)
         logger = validate_logger(logger)
-        return _Capturing(self, _Handler(self, levelno=levelno), logger=logger)
+        return _Capturing(self, _Handler(level, self), logger=logger)
 
     def capture(self, captured: Captured) -> None:
         """
@@ -245,10 +241,10 @@ class _Capturing:
 class _Handler(logging.Handler):
     __slots__ = ("_logot",)
 
-    def __init__(self, logot: Logot, *, levelno: int) -> None:
-        super().__init__(levelno)
+    def __init__(self, level: str | int, logot: Logot) -> None:
+        super().__init__(level)
         self._logot = logot
 
     def emit(self, record: logging.LogRecord) -> None:
-        captured = Captured(record.levelno, record.getMessage())
+        captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
         self._logot.capture(captured)

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -37,6 +37,8 @@ class Logot:
     DEFAULT_LOGGER: ClassVar[logging.Logger | str | None] = None
     """
     The default ``logger`` used by :meth:`capturing`.
+
+    This is the root logger.
     """
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -73,8 +73,8 @@ class Logot:
             See :doc:`captured` usage guide.
 
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric constant (e.g. :data:`logging.DEBUG`). Defaults to
-            :data:`logging.NOTSET`, specifying that all logs are captured.
-        :param logger: A logger or logger name to capture logs from. Defaults to the root logger.
+            :attr:`DEFAULT_LEVEL`.
+        :param logger: A logger or logger name to capture logs from. Defaults to :attr:`DEFAULT_LOGGER`.
         """
         level = validate_level(level)
         logger = validate_logger(logger)

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -41,9 +41,7 @@ class Logot:
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
-    The default ``timeout`` used by :meth:`wait_for` and :meth:`await_for`.
-
-    This is 3 seconds.
+    The default ``timeout`` (in seconds) used by :meth:`wait_for` and :meth:`await_for`.
     """
 
     def __init__(

--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -3,16 +3,10 @@ from __future__ import annotations
 import logging
 
 
-def validate_levelno(level: int | str) -> int:
-    # Handle `int` level.
-    if isinstance(level, int):
+def validate_level(level: str | int) -> str | int:
+    # Handle `str` or `int` level.
+    if isinstance(level, (str, int)):
         return level
-    # Handle `str` level.
-    if isinstance(level, str):
-        levelno = logging.getLevelName(level)
-        if not isinstance(levelno, int):
-            raise ValueError(f"Unknown level: {level!r}")
-        return levelno
     # Handle invalid level.
     raise TypeError(f"Invalid level: {level!r}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "logot"
-version = "0.2.0"
+version = "0.3.0"
 description = "Log-based testing"
 authors = ["Dave Hall <dave@etianen.com>"]
 license = "MIT"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,18 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from time import sleep
 
+from logot import Captured
+
 logger = logging.getLogger("logot")
+
+
+def log(levelname: str, msg: str, *, levelno: int | None = None) -> Captured:
+    # Look up default `levelno` from `logging`.
+    if levelno is None:
+        levelno = logging.getLevelName(levelname)
+        assert isinstance(levelno, int)
+    # All done!
+    return Captured(levelname, msg, levelno=levelno)
 
 
 def lines(*lines: str) -> str:

--- a/tests/test_captured.py
+++ b/tests/test_captured.py
@@ -6,19 +6,21 @@ from logot import Captured
 
 
 def test_eq_pass() -> None:
-    assert Captured(logging.INFO, "foo bar") == Captured(logging.INFO, "foo bar")
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.INFO)
 
 
 def test_eq_fail() -> None:
-    # Different levels are not equal.
-    assert Captured(logging.INFO, "foo bar") != Captured(logging.DEBUG, "foo bar")
+    # Different levelnames are not equal.
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("DEBUG", "foo bar", levelno=logging.INFO)
     # Different messages are not equal.
-    assert Captured(logging.INFO, "foo bar") != Captured(logging.INFO, "foo")
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo", levelno=logging.INFO)
+    # Different levelnos are not equal.
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.DEBUG)
 
 
 def test_repr() -> None:
-    assert repr(Captured(logging.INFO, "foo bar")) == "Captured('INFO', 'foo bar')"
+    assert repr(Captured("INFO", "foo bar", levelno=logging.INFO)) == "Captured('INFO', 'foo bar', levelno=20)"
 
 
 def test_str() -> None:
-    assert str(Captured(logging.INFO, "foo bar")) == "[INFO] foo bar"
+    assert str(Captured("INFO", "foo bar", levelno=logging.INFO)) == "[INFO] foo bar"

--- a/tests/test_captured.py
+++ b/tests/test_captured.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
+import logging
+
 from logot import Captured
 
 
 def test_eq_pass() -> None:
-    assert Captured("INFO", "foo bar", levelno=20) == Captured("INFO", "foo bar", levelno=20)
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.INFO)
 
 
 def test_eq_fail() -> None:
     # Different levelnames are not equal.
-    assert Captured("INFO", "foo bar", levelno=20) != Captured("DEBUG", "foo bar", levelno=20)
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("DEBUG", "foo bar", levelno=logging.INFO)
     # Different messages are not equal.
-    assert Captured("INFO", "foo bar", levelno=20) != Captured("INFO", "foo", levelno=20)
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo", levelno=logging.INFO)
     # Different levelnos are not equal.
-    assert Captured("INFO", "foo bar", levelno=20) != Captured("INFO", "foo bar", levelno=10)
+    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo bar", levelno=logging.DEBUG)
 
 
 def test_repr() -> None:
-    assert repr(Captured("INFO", "foo bar", levelno=20)) == "Captured('INFO', 'foo bar', levelno=20)"
+    assert repr(Captured("INFO", "foo bar", levelno=99)) == "Captured('INFO', 'foo bar', levelno=99)"
 
 
 def test_str() -> None:
-    assert str(Captured("INFO", "foo bar", levelno=20)) == "[INFO] foo bar"
+    assert str(Captured("INFO", "foo bar", levelno=logging.INFO)) == "[INFO] foo bar"

--- a/tests/test_captured.py
+++ b/tests/test_captured.py
@@ -1,26 +1,24 @@
 from __future__ import annotations
 
-import logging
-
 from logot import Captured
 
 
 def test_eq_pass() -> None:
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar", levelno=20) == Captured("INFO", "foo bar", levelno=20)
 
 
 def test_eq_fail() -> None:
     # Different levelnames are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("DEBUG", "foo bar", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar", levelno=20) != Captured("DEBUG", "foo bar", levelno=20)
     # Different messages are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar", levelno=20) != Captured("INFO", "foo", levelno=20)
     # Different levelnos are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.DEBUG)
+    assert Captured("INFO", "foo bar", levelno=20) != Captured("INFO", "foo bar", levelno=10)
 
 
 def test_repr() -> None:
-    assert repr(Captured("INFO", "foo bar", levelno=logging.INFO)) == "Captured('INFO', 'foo bar', levelno=20)"
+    assert repr(Captured("INFO", "foo bar", levelno=20)) == "Captured('INFO', 'foo bar', levelno=20)"
 
 
 def test_str() -> None:
-    assert str(Captured("INFO", "foo bar", levelno=logging.INFO)) == "[INFO] foo bar"
+    assert str(Captured("INFO", "foo bar", levelno=20)) == "[INFO] foo bar"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
-from logot._format import format_log
+import logging
+
+from logot._format import format_level, format_log
+
+
+def test_format_level_str() -> None:
+    assert format_level("INFO") == "INFO"
+
+
+def test_format_level_int() -> None:
+    assert format_level(logging.INFO) == "INFO"
 
 
 def test_format_log() -> None:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import logging
-
 from logot._format import format_log
 
 
 def test_format_log() -> None:
-    assert format_log(logging.INFO, "foo bar") == "[INFO] foo bar"
+    assert format_log("INFO", "foo bar") == "[INFO] foo bar"

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -38,6 +38,7 @@ def test_record_logged_repr() -> None:
 
 def test_record_logged_str() -> None:
     assert str(logged.log(logging.DEBUG, "foo bar")) == "[DEBUG] foo bar"
+    assert str(logged.log("DEBUG", "foo bar")) == "[DEBUG] foo bar"
     assert str(logged.debug("foo bar")) == "[DEBUG] foo bar"
     assert str(logged.info("foo bar")) == "[INFO] foo bar"
     assert str(logged.warning("foo bar")) == "[WARNING] foo bar"

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -46,8 +46,16 @@ def test_record_logged_str() -> None:
 
 
 def test_record_logged_reduce() -> None:
+    # Test `str` level.
     assert_reduce(
-        logged.info("foo bar"),
+        logged.log("INFO", "foo bar"),
+        log("INFO", "boom!"),  # Non-matching.
+        log("DEBUG", "foo bar"),  # Non-matching.
+        log("INFO", "foo bar"),  # Matching.
+    )
+    # Test `int` level.
+    assert_reduce(
+        logged.log(logging.INFO, "foo bar"),
         log("INFO", "boom!"),  # Non-matching.
         log("DEBUG", "foo bar"),  # Non-matching.
         log("INFO", "foo bar"),  # Matching.

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from logot import Captured, Logged, logged
-from tests import lines
+from tests import lines, log
 
 
 def assert_reduce(logged: Logged | None, *captured_items: Captured) -> None:
@@ -27,7 +27,8 @@ def test_record_logged_eq_fail() -> None:
 
 
 def test_record_logged_repr() -> None:
-    assert repr(logged.log(logging.DEBUG, "foo bar")) == "log('DEBUG', 'foo bar')"
+    assert repr(logged.log(10, "foo bar")) == "log(10, 'foo bar')"
+    assert repr(logged.log("DEBUG", "foo bar")) == "log('DEBUG', 'foo bar')"
     assert repr(logged.debug("foo bar")) == "log('DEBUG', 'foo bar')"
     assert repr(logged.info("foo bar")) == "log('INFO', 'foo bar')"
     assert repr(logged.warning("foo bar")) == "log('WARNING', 'foo bar')"
@@ -47,9 +48,9 @@ def test_record_logged_str() -> None:
 def test_record_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo bar"),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.DEBUG, "foo bar"),  # Non-matching.
-        Captured(logging.INFO, "foo bar"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("DEBUG", "foo bar"),  # Non-matching.
+        log("INFO", "foo bar"),  # Matching.
     )
 
 
@@ -113,23 +114,23 @@ def test_ordered_all_logged_str() -> None:
 def test_ordered_all_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") >> logged.info("bar") >> logged.info("baz"),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "baz"),  # Non-matching.
-        Captured(logging.INFO, "bar"),  # Non-matching.
-        Captured(logging.INFO, "foo"),  # Matching.
-        Captured(logging.INFO, "foo"),  # Non-matching.
-        Captured(logging.INFO, "bar"),  # Matching.
-        Captured(logging.INFO, "baz"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "baz"),  # Non-matching.
+        log("INFO", "bar"),  # Non-matching.
+        log("INFO", "foo"),  # Matching.
+        log("INFO", "foo"),  # Non-matching.
+        log("INFO", "bar"),  # Matching.
+        log("INFO", "baz"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") & logged.info("foo2")) >> (logged.info("bar1") & logged.info("bar2")),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "bar2"),  # Non-matching.
-        Captured(logging.INFO, "foo2"),  # Matching.
-        Captured(logging.INFO, "bar1"),  # Non-matching.
-        Captured(logging.INFO, "foo1"),  # Matching.
-        Captured(logging.INFO, "bar2"),  # Matching.
-        Captured(logging.INFO, "bar1"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "bar2"),  # Non-matching.
+        log("INFO", "foo2"),  # Matching.
+        log("INFO", "bar1"),  # Non-matching.
+        log("INFO", "foo1"),  # Matching.
+        log("INFO", "bar2"),  # Matching.
+        log("INFO", "bar1"),  # Matching.
     )
 
 
@@ -193,21 +194,21 @@ def test_unordered_all_logged_str() -> None:
 def test_unordered_all_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") & logged.info("bar") & logged.info("baz"),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "baz"),  # Matching.
-        Captured(logging.INFO, "baz"),  # Non-matching.
-        Captured(logging.INFO, "bar"),  # Matching.
-        Captured(logging.INFO, "foo"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "baz"),  # Matching.
+        log("INFO", "baz"),  # Non-matching.
+        log("INFO", "bar"),  # Matching.
+        log("INFO", "foo"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") >> logged.info("foo2")) & (logged.info("bar1") >> logged.info("bar2")),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "bar2"),  # Non-matching.
-        Captured(logging.INFO, "foo2"),  # Non-matching.
-        Captured(logging.INFO, "bar1"),  # Matching.
-        Captured(logging.INFO, "foo1"),  # Matching.
-        Captured(logging.INFO, "foo2"),  # Matching.
-        Captured(logging.INFO, "bar2"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "bar2"),  # Non-matching.
+        log("INFO", "foo2"),  # Non-matching.
+        log("INFO", "bar1"),  # Matching.
+        log("INFO", "foo1"),  # Matching.
+        log("INFO", "foo2"),  # Matching.
+        log("INFO", "bar2"),  # Matching.
     )
 
 
@@ -271,15 +272,15 @@ def test_any_logged_str() -> None:
 def test_any_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") | logged.info("bar") | logged.info("baz"),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "bar"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "bar"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") >> logged.info("foo2")) | (logged.info("bar1") >> logged.info("bar2")),
-        Captured(logging.INFO, "boom!"),  # Non-matching.
-        Captured(logging.INFO, "bar2"),  # Non-matching.
-        Captured(logging.INFO, "foo2"),  # Non-matching.
-        Captured(logging.INFO, "bar1"),  # Matching.
-        Captured(logging.INFO, "foo1"),  # Matching.
-        Captured(logging.INFO, "foo2"),  # Matching.
+        log("INFO", "boom!"),  # Non-matching.
+        log("INFO", "bar2"),  # Non-matching.
+        log("INFO", "foo2"),  # Non-matching.
+        log("INFO", "bar1"),  # Matching.
+        log("INFO", "foo1"),  # Matching.
+        log("INFO", "foo2"),  # Matching.
     )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,27 +5,21 @@ from typing import cast
 
 import pytest
 
-from logot._validate import validate_levelno, validate_logger, validate_timeout
+from logot._validate import validate_level, validate_logger, validate_timeout
 from tests import logger
 
 
-def test_validate_levelno_int_pass() -> None:
-    assert validate_levelno(logging.INFO) == logging.INFO
+def test_validate_level_str_pass() -> None:
+    assert validate_level("INFO") == "INFO"
 
 
-def test_validate_levelno_str_pass() -> None:
-    assert validate_levelno("INFO") == logging.INFO
+def test_validate_level_int_pass() -> None:
+    assert validate_level(20) == 20
 
 
-def test_validate_levelno_str_fail() -> None:
-    with pytest.raises(ValueError) as ex:
-        validate_levelno("BOOM")
-    assert str(ex.value) == "Unknown level: 'BOOM'"
-
-
-def test_validate_levelno_type_fail() -> None:
+def test_validate_level_type_fail() -> None:
     with pytest.raises(TypeError) as ex:
-        validate_levelno(cast(int, 1.5))
+        validate_level(cast(int, 1.5))
     assert str(ex.value) == "Invalid level: 1.5"
 
 


### PR DESCRIPTION
`Captured` now takes an explicit `levelname` and `levelno`. This allows 3rd-party logging framework integrations to be freed of the obligation to match stdlib `logging` levels.

The validation of `validate_levelno` was relaxed to just validate the type of the input, and correspondingly renamed to `validate_level`.

The `DEFAULT_XXX` class attributes on `Logot` were updated to prefer `str` and use string constants for easier reading in docs. The typing of log levels everywhere was updated to prefer `str` for better compatibility with 3rd-party logging frameworks.

The named logging helpers in `logged` were updated to use string level names for better compatibility with 3rd-party logging frameworks.

Needed by #28.