### PR TITLE
Making `Captured.levelno` optional

### DIFF
--- a/docs/captured.rst
+++ b/docs/captured.rst
@@ -48,7 +48,7 @@ Any 3rd-party logging library can be integrated with :mod:`logot` by sending :cl
 .. code:: python
 
    def on_foo_log(logot: Logot, record: FooRecord) -> None:
-      logot.capture(Captured(record.levelname, record.msg, levelno=record.levelno))
+      logot.capture(Captured(record.levelname, record.msg))
 
    foo_logger.add_handler(on_foo_log)
 

--- a/logot/_captured.py
+++ b/logot/_captured.py
@@ -8,7 +8,7 @@ class Captured:
     A captured log record.
 
     Send :class:`Captured` logs to :meth:`Logot.capture` to integrate with
-    :ref:`3rd-party logging frameworks <captured-3rd-party>`
+    :ref:`3rd-party logging frameworks <captured-3rd-party>`.
 
     .. note::
 
@@ -19,9 +19,9 @@ class Captured:
 
         See :ref:`captured-3rd-party` usage guide.
 
-    :param levelname: The log level name (e.g. ``"DEBUG"``).
-    :param msg: The log message.
-    :param levelno: The log level number (e.g. :data:`logging.DEBUG`).
+    :param levelname: See :attr:`Captured.levelname`.
+    :param msg: See :attr:`Captured.msg`.
+    :param levelno: See :attr:`Captured.levelno`.
     """
 
     __slots__ = ("levelname", "msg", "levelno")
@@ -36,12 +36,15 @@ class Captured:
     The log message.
     """
 
-    levelno: int
+    levelno: int | None
     """
     The log level number (e.g. :data:`logging.DEBUG`).
+
+    This is an *optional* log capture field. When provided, it allows matching :doc:`log patterns <logged>` from
+    :func:`logged.log` with a numeric ``level``.
     """
 
-    def __init__(self, levelname: str, msg: str, *, levelno: int) -> None:
+    def __init__(self, levelname: str, msg: str, *, levelno: int | None = None) -> None:
         self.levelname = levelname
         self.msg = msg
         self.levelno = levelno

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -61,7 +61,7 @@ def log(level: str | int, msg: str) -> Logged:
     """
     Creates a :doc:`log pattern <logged>` representing a log record at the given ``level`` with the given ``msg``.
 
-    :param level: A log level name (e.g. ``"DEBUG"``) or numeric constant (e.g. :data:`logging.DEBUG`).
+    :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`).
     :param msg: A log :doc:`message pattern <match>`.
     """
     return _RecordLogged(validate_level(level), msg)

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -24,7 +24,7 @@ class Logot:
         See :doc:`index` usage guide.
 
     :param timeout: The default timeout (in seconds) for calls to :meth:`wait_for` and :meth:`await_for`. Defaults to
-        :attr:`DEFAULT_TIMEOUT`.
+        :attr:`Logot.DEFAULT_TIMEOUT`.
     """
 
     __slots__ = ("_timeout", "_lock", "_queue", "_waiter")
@@ -72,9 +72,9 @@ class Logot:
 
             See :doc:`captured` usage guide.
 
-        :param level: A log level name (e.g. ``"DEBUG"``) or numeric constant (e.g. :data:`logging.DEBUG`). Defaults to
-            :attr:`DEFAULT_LEVEL`.
-        :param logger: A logger or logger name to capture logs from. Defaults to :attr:`DEFAULT_LOGGER`.
+        :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
+            :attr:`Logot.DEFAULT_LEVEL`.
+        :param logger: A logger or logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
         """
         level = validate_level(level)
         logger = validate_logger(logger)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "logot"
-version = "0.3.0"
+version = "0.3.1"
 description = "Log-based testing"
 authors = ["Dave Hall <dave@etianen.com>"]
 license = "MIT"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,18 +6,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from time import sleep
 
-from logot import Captured
-
 logger = logging.getLogger("logot")
-
-
-def log(levelname: str, msg: str, *, levelno: int | None = None) -> Captured:
-    # Look up default `levelno` from `logging`.
-    if levelno is None:
-        levelno = logging.getLevelName(levelname)
-        assert isinstance(levelno, int)
-    # All done!
-    return Captured(levelname, msg, levelno=levelno)
 
 
 def lines(*lines: str) -> str:

--- a/tests/test_captured.py
+++ b/tests/test_captured.py
@@ -6,21 +6,21 @@ from logot import Captured
 
 
 def test_eq_pass() -> None:
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) == Captured("INFO", "foo bar", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar") == Captured("INFO", "foo bar")
 
 
 def test_eq_fail() -> None:
     # Different levelnames are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("DEBUG", "foo bar", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar") != Captured("DEBUG", "foo bar")
     # Different messages are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo", levelno=logging.INFO)
+    assert Captured("INFO", "foo bar") != Captured("INFO", "foo")
     # Different levelnos are not equal.
-    assert Captured("INFO", "foo bar", levelno=logging.INFO) != Captured("INFO", "foo bar", levelno=logging.DEBUG)
+    assert Captured("INFO", "foo bar") != Captured("INFO", "foo bar", levelno=logging.DEBUG)
 
 
 def test_repr() -> None:
-    assert repr(Captured("INFO", "foo bar", levelno=99)) == "Captured('INFO', 'foo bar', levelno=99)"
+    assert repr(Captured("INFO", "foo bar")) == "Captured('INFO', 'foo bar', levelno=None)"
 
 
 def test_str() -> None:
-    assert str(Captured("INFO", "foo bar", levelno=logging.INFO)) == "[INFO] foo bar"
+    assert str(Captured("INFO", "foo bar")) == "[INFO] foo bar"

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -57,9 +57,8 @@ def test_record_logged_reduce() -> None:
     # Test `int` level.
     assert_reduce(
         logged.log(logging.INFO, "foo bar"),
-        Captured("INFO", "boom!"),  # Non-matching.
-        Captured("DEBUG", "foo bar"),  # Non-matching.
-        Captured("INFO", "foo bar"),  # Matching.
+        Captured("INFO", "foo bar"),  # Non-matching (needs levelno).
+        Captured("INFO", "foo bar", levelno=logging.INFO),  # Matching.
     )
 
 

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from logot import Captured, Logged, logged
-from tests import lines, log
+from tests import lines
 
 
 def assert_reduce(logged: Logged | None, *captured_items: Captured) -> None:
@@ -50,16 +50,16 @@ def test_record_logged_reduce() -> None:
     # Test `str` level.
     assert_reduce(
         logged.log("INFO", "foo bar"),
-        log("INFO", "boom!"),  # Non-matching.
-        log("DEBUG", "foo bar"),  # Non-matching.
-        log("INFO", "foo bar"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("DEBUG", "foo bar"),  # Non-matching.
+        Captured("INFO", "foo bar"),  # Matching.
     )
     # Test `int` level.
     assert_reduce(
         logged.log(logging.INFO, "foo bar"),
-        log("INFO", "boom!"),  # Non-matching.
-        log("DEBUG", "foo bar"),  # Non-matching.
-        log("INFO", "foo bar"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("DEBUG", "foo bar"),  # Non-matching.
+        Captured("INFO", "foo bar"),  # Matching.
     )
 
 
@@ -123,23 +123,23 @@ def test_ordered_all_logged_str() -> None:
 def test_ordered_all_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") >> logged.info("bar") >> logged.info("baz"),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "baz"),  # Non-matching.
-        log("INFO", "bar"),  # Non-matching.
-        log("INFO", "foo"),  # Matching.
-        log("INFO", "foo"),  # Non-matching.
-        log("INFO", "bar"),  # Matching.
-        log("INFO", "baz"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "baz"),  # Non-matching.
+        Captured("INFO", "bar"),  # Non-matching.
+        Captured("INFO", "foo"),  # Matching.
+        Captured("INFO", "foo"),  # Non-matching.
+        Captured("INFO", "bar"),  # Matching.
+        Captured("INFO", "baz"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") & logged.info("foo2")) >> (logged.info("bar1") & logged.info("bar2")),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "bar2"),  # Non-matching.
-        log("INFO", "foo2"),  # Matching.
-        log("INFO", "bar1"),  # Non-matching.
-        log("INFO", "foo1"),  # Matching.
-        log("INFO", "bar2"),  # Matching.
-        log("INFO", "bar1"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "bar2"),  # Non-matching.
+        Captured("INFO", "foo2"),  # Matching.
+        Captured("INFO", "bar1"),  # Non-matching.
+        Captured("INFO", "foo1"),  # Matching.
+        Captured("INFO", "bar2"),  # Matching.
+        Captured("INFO", "bar1"),  # Matching.
     )
 
 
@@ -203,21 +203,21 @@ def test_unordered_all_logged_str() -> None:
 def test_unordered_all_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") & logged.info("bar") & logged.info("baz"),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "baz"),  # Matching.
-        log("INFO", "baz"),  # Non-matching.
-        log("INFO", "bar"),  # Matching.
-        log("INFO", "foo"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "baz"),  # Matching.
+        Captured("INFO", "baz"),  # Non-matching.
+        Captured("INFO", "bar"),  # Matching.
+        Captured("INFO", "foo"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") >> logged.info("foo2")) & (logged.info("bar1") >> logged.info("bar2")),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "bar2"),  # Non-matching.
-        log("INFO", "foo2"),  # Non-matching.
-        log("INFO", "bar1"),  # Matching.
-        log("INFO", "foo1"),  # Matching.
-        log("INFO", "foo2"),  # Matching.
-        log("INFO", "bar2"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "bar2"),  # Non-matching.
+        Captured("INFO", "foo2"),  # Non-matching.
+        Captured("INFO", "bar1"),  # Matching.
+        Captured("INFO", "foo1"),  # Matching.
+        Captured("INFO", "foo2"),  # Matching.
+        Captured("INFO", "bar2"),  # Matching.
     )
 
 
@@ -281,15 +281,15 @@ def test_any_logged_str() -> None:
 def test_any_logged_reduce() -> None:
     assert_reduce(
         logged.info("foo") | logged.info("bar") | logged.info("baz"),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "bar"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "bar"),  # Matching.
     )
     assert_reduce(
         (logged.info("foo1") >> logged.info("foo2")) | (logged.info("bar1") >> logged.info("bar2")),
-        log("INFO", "boom!"),  # Non-matching.
-        log("INFO", "bar2"),  # Non-matching.
-        log("INFO", "foo2"),  # Non-matching.
-        log("INFO", "bar1"),  # Matching.
-        log("INFO", "foo1"),  # Matching.
-        log("INFO", "foo2"),  # Matching.
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "bar2"),  # Non-matching.
+        Captured("INFO", "foo2"),  # Non-matching.
+        Captured("INFO", "bar1"),  # Matching.
+        Captured("INFO", "foo1"),  # Matching.
+        Captured("INFO", "foo2"),  # Matching.
     )


### PR DESCRIPTION
This makes it easier to integrate 3rd-party logging frameworks by making less assumptions about what a logging framework might provide. It also establishes a pattern for adding new `Captured` fields in future.