### PR TITLE
Hierarchical API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/logot.svg)](https://pypi.org/project/logot/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/logot.svg)](https://pypi.org/project/logot/)
 
-`logot` makes it easy to test your application is logging correctly:
+`logot` makes it easy to test whether your code is logging correctly:
 
 ``` python
 from logot import Logot, logged

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,22 @@
+API reference
+=============
+
+.. currentmodule:: logot
+
+Import the :mod:`logot` API in your tests:
+
+.. code:: python
+
+   from logot import Logot, logged
+
+
+Modules
+-------
+
+Learn about the public :mod:`logot` modules with the following reference guides:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   logot*

--- a/docs/api/logot.logged.rst
+++ b/docs/api/logot.logged.rst
@@ -3,6 +3,10 @@
 
 .. automodule:: logot.logged
 
+
+API reference
+-------------
+
 .. autofunction:: logot.logged.log
 
 .. autofunction:: logot.logged.debug

--- a/docs/api/logot.logged.rst
+++ b/docs/api/logot.logged.rst
@@ -1,0 +1,16 @@
+:mod:`logot.logged`
+===================
+
+.. automodule:: logot.logged
+
+.. autofunction:: logot.logged.log
+
+.. autofunction:: logot.logged.debug
+
+.. autofunction:: logot.logged.info
+
+.. autofunction:: logot.logged.warning
+
+.. autofunction:: logot.logged.error
+
+.. autofunction:: logot.logged.critical

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -1,19 +1,11 @@
-API reference
-=============
-
-.. currentmodule:: logot
-
-Import the :mod:`logot` API in your tests:
-
-.. code:: python
-
-   from logot import Logot, logged
-
-
 :mod:`logot`
-------------
+============
 
-.. module:: logot
+.. automodule:: logot
+
+
+API reference
+-------------
 
 .. autoclass:: logot.Logot
 
@@ -46,21 +38,3 @@ Import the :mod:`logot` API in your tests:
    .. autoattribute:: msg
 
    .. autoattribute:: levelno
-
-
-:mod:`logot.logged`
--------------------
-
-.. module:: logot.logged
-
-.. autofunction:: logot.logged.log
-
-.. autofunction:: logot.logged.debug
-
-.. autofunction:: logot.logged.info
-
-.. autofunction:: logot.logged.warning
-
-.. autofunction:: logot.logged.error
-
-.. autofunction:: logot.logged.critical

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Log-based testing 🪵
 
 .. note::
 
-   These examples all show using :mod:`logot` with :mod:`pytest`. See :doc:`usage-unittest` to learn about about using
+   These examples all show using :mod:`logot` with :mod:`pytest`. See :doc:`/usage-unittest` to learn about about using
    :mod:`logot` with other testing frameworks.
 
 
@@ -84,7 +84,7 @@ Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or 
 
 .. seealso::
 
-   See :doc:`log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
+   See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
 
 
 Testing asynchronous code
@@ -107,7 +107,7 @@ Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or
 
 .. seealso::
 
-   See :doc:`log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
+   See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
 
 
 Testing synchronous code
@@ -144,7 +144,6 @@ Learn more about :mod:`logot` with the following guides:
 
    self
 
-
 .. toctree::
    :maxdepth: 1
 
@@ -153,4 +152,4 @@ Learn more about :mod:`logot` with the following guides:
    log-capturing
    usage-pytest
    usage-unittest
-   api
+   api/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ Log-based testing 🪵
 
 .. currentmodule:: logot
 
-:mod:`logot` makes it easy to test your application is logging correctly:
+:mod:`logot` makes it easy to test whether your code is logging correctly:
 
 .. code:: python
 
@@ -22,12 +22,11 @@ Log-based testing 🪵
 Why test logging? 🤔
 --------------------
 
-Good logging ensures your application is debuggable at runtime, but why bother actually *testing* your logs? After
-all... surely the worst that can happen is your logs are a bit *wonky*? 🥴
+Good logging ensures your code is debuggable at runtime, but why bother actually *testing* your logs? After all...
+surely the worst that can happen is your logs are a bit *wonky*? 🥴
 
 Sometimes, testing logs is the only *reasonable* way to known your code has actually run correctly! This is particularly
-the case in *threaded* or *asynchronous* applications where work is carried out at unpredictable times by background
-workers.
+the case in *threaded* or *asynchronous* code where work is carried out at unpredictable times by background workers.
 
 For example, imagine the following code running in a thread:
 
@@ -47,8 +46,7 @@ For example, imagine the following code running in a thread:
 .. note::
 
    It's certainly *possible* to rewrite this code in a way that can be tested without :mod:`logot`, but that often makes
-   the code less clear or more verbose. For complex threaded or asynchronous applications, this can quickly become
-   burdensome.
+   the code less clear or more verbose. For complex threaded or asynchronous code, this can quickly become burdensome.
    👎
 
 Testing this code with :mod:`logot` is easy!

--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -14,7 +14,7 @@ Log capturing
 .. note::
 
    If using :mod:`pytest`, you can probably just use the pre-configured ``logot`` fixture included in the bundled
-   :doc:`pytest plugin <usage-pytest>` and skip manually configuring log capture. 💪
+   :doc:`pytest plugin </usage-pytest>` and skip manually configuring log capture. 💪
 
 
 Capturing :mod:`logging` logs

--- a/docs/log-pattern-matching.rst
+++ b/docs/log-pattern-matching.rst
@@ -4,7 +4,7 @@ Log pattern matching
 .. currentmodule:: logot
 
 :mod:`logot` makes it easy to match logs that may arrive in an unpredictable order. This is especially useful in
-*threaded* or *asynchronous* applications!
+*threaded* or *asynchronous* code!
 
 Compose your :mod:`logot.logged` calls with special *log pattern operators*:
 

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -1,3 +1,10 @@
+"""
+Main :mod:`logot` API for log-based testing.
+
+.. seealso::
+
+    See :doc:`/index` usage guide.
+"""
 from __future__ import annotations
 
 from logot._captured import Captured as Captured

--- a/logot/_captured.py
+++ b/logot/_captured.py
@@ -41,7 +41,7 @@ class Captured:
     The log level number (e.g. :data:`logging.DEBUG`).
 
     This is an *optional* log capture field. When provided, it allows matching
-    :doc:`log patterns <log-pattern-matching>` from :func:`logged.log` with a numeric ``level``.
+    :doc:`log patterns </log-pattern-matching>` from :func:`logged.log` with a numeric ``level``.
     """
 
     def __init__(self, levelname: str, msg: str, *, levelno: int | None = None) -> None:

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -10,7 +10,7 @@ from logot._validate import validate_level
 
 class Logged(ABC):
     """
-    A :doc:`log pattern <log-pattern-matching>` passed to :meth:`Logot.wait_for`, :meth:`Logot.await_for` and related
+    A :doc:`log pattern </log-pattern-matching>` passed to :meth:`Logot.wait_for`, :meth:`Logot.await_for` and related
     APIs.
 
     .. important::
@@ -24,7 +24,7 @@ class Logged(ABC):
 
     .. seealso::
 
-        See :doc:`log-pattern-matching` usage guide.
+        See :doc:`/log-pattern-matching` usage guide.
     """
 
     __slots__ = ()
@@ -60,61 +60,61 @@ class Logged(ABC):
 
 def log(level: str | int, msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at the given ``level`` with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at the given ``level`` with the given
     ``msg``.
 
     :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`).
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged(validate_level(level), msg)
 
 
 def debug(msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at ``DEBUG`` level with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``DEBUG`` level with the given
     ``msg``.
 
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged("DEBUG", msg)
 
 
 def info(msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at ``INFO`` level with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``INFO`` level with the given
     ``msg``.
 
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged("INFO", msg)
 
 
 def warning(msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at ``WARNING`` level with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``WARNING`` level with the given
     ``msg``.
 
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged("WARNING", msg)
 
 
 def error(msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at ``ERROR`` level with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``ERROR`` level with the given
     ``msg``.
 
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged("ERROR", msg)
 
 
 def critical(msg: str) -> Logged:
     """
-    Creates a :doc:`log pattern <log-pattern-matching>` representing a log record at ``CRITICAL`` level with the given
+    Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``CRITICAL`` level with the given
     ``msg``.
 
-    :param msg: A log :doc:`message pattern <log-message-matching>`.
+    :param msg: A log :doc:`message pattern </log-message-matching>`.
     """
     return _RecordLogged("CRITICAL", msg)
 

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -21,7 +21,7 @@ class Logot:
 
     .. seealso::
 
-        See :doc:`index` usage guide.
+        See :doc:`/index` usage guide.
 
     :param timeout: The default timeout (in seconds) for calls to :meth:`wait_for` and :meth:`await_for`. Defaults to
         :attr:`Logot.DEFAULT_TIMEOUT`.
@@ -70,7 +70,7 @@ class Logot:
 
         .. seealso::
 
-            See :doc:`log-capturing` usage guide.
+            See :doc:`/log-capturing` usage guide.
 
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
             :attr:`Logot.DEFAULT_LEVEL`.
@@ -85,7 +85,7 @@ class Logot:
         Adds the given captured log record to the internal capture queue.
 
         Any waiters blocked on :meth:`wait_for` to :meth:`await_for` will be notified and wake up if their
-        :doc:`log pattern <log-pattern-matching>` is satisfied.
+        :doc:`log pattern </log-pattern-matching>` is satisfied.
 
         .. note::
 
@@ -113,7 +113,7 @@ class Logot:
         """
         Waits for the expected ``log`` pattern to arrive or the ``timeout`` to expire.
 
-        :param logged: The expected :doc:`log pattern <log-pattern-matching>`.
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to the ``timeout`` passed to
             :class:`Logot`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
@@ -128,7 +128,7 @@ class Logot:
         """
         Waits *asynchronously* for the expected ``log`` pattern to arrive or the ``timeout`` to expire.
 
-        :param logged: The expected :doc:`log pattern <log-pattern-matching>`.
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to the ``timeout`` passed to
             :class:`Logot`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
@@ -143,7 +143,7 @@ class Logot:
         """
         Fails *immediately* if the expected ``log`` pattern has not arrived.
 
-        :param logged: The expected :doc:`log pattern <log-pattern-matching>`.
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :raises AssertionError: If the expected ``log`` pattern has not arrived.
         """
         reduced = self._reduce(logged)
@@ -154,7 +154,7 @@ class Logot:
         """
         Fails *immediately* if the expected ``log`` pattern **has** arrived.
 
-        :param logged: The expected :doc:`log pattern <log-pattern-matching>`.
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :raises AssertionError: If the expected ``log`` pattern **has** arrived.
         """
         reduced = self._reduce(logged)

--- a/logot/logged.py
+++ b/logot/logged.py
@@ -1,3 +1,10 @@
+"""
+Log :doc:`pattern matching </log-pattern-matching>` API.
+
+.. seealso::
+
+    See :doc:`/log-pattern-matching` usage guide.
+"""
 from __future__ import annotations
 
 from logot._logged import critical as critical


### PR DESCRIPTION
- Added minimal docstrings to public modules.
- Switched to absolute `:doc:` references.
- Tweaked some taglines.