### PR TITLE
Test against multiple versions of `pytest`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,6 +12,9 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: poetry
+    # Configure poetry.
+    - run: poetry config virtualenvs.create false
+      shell: bash
     # Run pre-install checks.
     - run: poetry check
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,11 +12,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: poetry
-    # Configure poetry.
-    # It's convenient to not use `poetry run` all the time, and the `actions/setup-python` action docs seem to indicate
-    # a venv is not necessary.
-    - run: poetry config virtualenvs.create false
-      shell: bash
     # Run pre-install checks.
     - run: poetry check
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,8 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: poetry
     # Configure poetry.
+    # It's convenient to not have to use `poetry run` all the time, and the `actions/setup-python` action seems to
+    # indicate a venv is not necessary.
     - run: poetry config virtualenvs.create false
       shell: bash
     # Run pre-install checks.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,8 +13,8 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: poetry
     # Configure poetry.
-    # It's convenient to not have to use `poetry run` all the time, and the `actions/setup-python` action seems to
-    # indicate a venv is not necessary.
+    # It's convenient to not use `poetry run` all the time, and the `actions/setup-python` action docs seem to indicate
+    # a venv is not necessary.
     - run: poetry config virtualenvs.create false
       shell: bash
     # Run pre-install checks.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   test:
+    name: test (python~=${{ matrix.python-version }} pytest${{ matric.pytest-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -16,6 +17,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+        pytest-version:
+          - "~=7.0"
+          - "~=8.0"
       fail-fast: false
     env:
       PYTHONDEVMODE: 1
@@ -28,17 +32,19 @@ jobs:
         python-version: ${{ matrix.python-version }}
     # Install dependencies.
     - name: Install dependencies
-      run: poetry install
+      run: |
+        poetry install --no-root
+        pip install -e .[pytest] "pytest${{ matric.pytest-version }}"
     # Run checks.
     - name: Check (ruff)
-      run: poetry run ruff check
+      run: ruff check
     - name: Check (ruff format)
-      run: poetry run ruff format --check
+      run: ruff format --check
     - name: Check (mypy)
-      run: poetry run mypy
+      run: mypy
     # Run tests.
     - name: Test
-      run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
+      run: coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
     - name: Upload coverage
       uses: actions/upload-artifact@v4
@@ -58,7 +64,7 @@ jobs:
       run: poetry install --without dev --with docs
     # Build docs.
     - name: Build docs
-      run: poetry run sphinx-build -W docs docs/_build
+      run: sphinx-build -W docs docs/_build
 
   report:
     runs-on: ubuntu-latest
@@ -81,9 +87,9 @@ jobs:
         pattern: coverage-*
         merge-multiple: true
     - name: Combine coverage
-      run: poetry run coverage combine .coverage-*
+      run: coverage combine .coverage-*
     - name: Report coverage
-      run: poetry run coverage report
+      run: coverage report
     # Fail if any `needs` job was not a success.
     # Along with `if: always()`, this allows this job to act as a single required status check for the entire workflow.
     - name: Fail on workflow error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   test:
-    name: test (python~=${{ matrix.python-version }} pytest${{ matric.pytest-version }})
+    name: test (python~=${{ matrix.python-version }} pytest${{ matrix.pytest-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install --no-root
-        pip install -e .[pytest] "pytest${{ matric.pytest-version }}"
+        pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
     - name: Check (ruff)
       run: ruff check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install --no-root
-        pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
+        poetry run pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
     - name: Check (ruff)
       run: poetry run ruff check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   test:
-    name: test (python~=${{ matrix.python-version }} pytest${{ matrix.pytest-version }})
+    name: test (python~=${{ matrix.python-version }}, pytest${{ matrix.pytest-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     # Install dependencies.
+    # This is done in two steps - first we install the `poetry` dev dependencies, then we install the project in
+    # editable mode with compatible `extra` dependencies from the test matrix. This is a compromise that allows us to
+    # largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
     - name: Install dependencies
       run: |
         poetry install --no-root --without main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       run: poetry run mypy
     # Run tests.
     - name: Test
-      run: coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
+      run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
     # Upload coverage.
     - name: Upload coverage
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
           - "~=8.0"
       fail-fast: false
     env:
+      COVERAGE_FILE: .coverage-${{ matrix.python-version }}-${{ matrix.pytest-version }}
       PYTHONDEVMODE: 1
     steps:
     - name: Checkout
@@ -44,13 +45,13 @@ jobs:
       run: poetry run mypy
     # Run tests.
     - name: Test
-      run: poetry run coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
+      run: poetry run coverage run -m pytest
     # Upload coverage.
     - name: Upload coverage
       uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ matrix.python-version }}
-        path: .coverage-${{ matrix.python-version }}
+        name: ${{ env.COVERAGE_FILE }}
+        path: ${{ env.COVERAGE_FILE }}
 
   docs:
     runs-on: ubuntu-latest
@@ -84,7 +85,7 @@ jobs:
     - name: Download coverage
       uses: actions/download-artifact@v4
       with:
-        pattern: coverage-*
+        pattern: .coverage-*
         merge-multiple: true
     - name: Combine coverage
       run: poetry run coverage combine .coverage-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     # largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
     - name: Install dependencies
       run: |
-        poetry install --no-root --without main
+        poetry install --no-root
         poetry run pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
     - name: Check (ruff)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     # Install dependencies.
     - name: Install dependencies
       run: |
-        poetry install --no-root
+        poetry install --no-root --without main
         poetry run pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
     - name: Check (ruff)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
         poetry install --no-root
         pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
-    - run: poetry run which ruff
     - name: Check (ruff)
       run: ruff check
     - name: Check (ruff format)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,13 +36,12 @@ jobs:
         poetry install --no-root
         pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
-    - run: python3 -c 'import ruff; ruff.__file__'
     - name: Check (ruff)
-      run: ruff check
+      run: poetry run ruff check
     - name: Check (ruff format)
-      run: ruff format --check
+      run: poetry run ruff format --check
     - name: Check (mypy)
-      run: mypy
+      run: poetry run mypy
     # Run tests.
     - name: Test
       run: coverage run --data-file=".coverage-${{ matrix.python-version }}" -m pytest
@@ -65,7 +64,7 @@ jobs:
       run: poetry install --without dev --with docs
     # Build docs.
     - name: Build docs
-      run: sphinx-build -W docs docs/_build
+      run: poetry run sphinx-build -W docs docs/_build
 
   report:
     runs-on: ubuntu-latest
@@ -88,9 +87,9 @@ jobs:
         pattern: coverage-*
         merge-multiple: true
     - name: Combine coverage
-      run: coverage combine .coverage-*
+      run: poetry run coverage combine .coverage-*
     - name: Report coverage
-      run: coverage report
+      run: poetry run coverage report
     # Fail if any `needs` job was not a success.
     # Along with `if: always()`, this allows this job to act as a single required status check for the entire workflow.
     - name: Fail on workflow error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         poetry install --no-root
         pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
+    - run: python3 -c 'import ruff; ruff.__file__'
     - name: Check (ruff)
       run: ruff check
     - name: Check (ruff format)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
         poetry install --no-root
         pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
+    - run: poetry run which ruff
     - name: Check (ruff)
       run: ruff check
     - name: Check (ruff format)

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 /.coverage
 /.hypothesis
 /.mypy_cache
-/.venv
 /dist
 /docs/_build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For non-trivial features and changes, please [open an issue](https://github.com/
 3. Install dependencies and activate your project:
 
    ``` bash
-   poetry install
+   poetry install --all-extras
    poetry shell
    ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -350,7 +350,7 @@ files = [
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
@@ -531,7 +531,7 @@ files = [
 name = "pluggy"
 version = "1.4.0"
 description = "plugin and hook calling mechanisms for python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
@@ -561,7 +561,7 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pytest"
 version = "8.0.0"
 description = "pytest: simple powerful testing with Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
@@ -899,4 +899,4 @@ pytest = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "54c21e36cf6dac94446730d73c9fa06a39e64397fc5825af540026b0751769a9"
+content-hash = "cdd827ccf1bed3dada02dc22088204bcd0e3a58e8fe7917b9141a67d1673109b"

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,3 +1,0 @@
-[virtualenvs.options]
-no-pip = true
-no-setuptools = true

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,6 +1,3 @@
-[virtualenvs]
-in-project = true
-
 [virtualenvs.options]
 no-pip = true
 no-setuptools = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ coverage = "^7.4.1"
 hypothesis = "^6.96.1"
 mypy = "^1.8.0"
 ruff = "^0.1.11"
-pytest = "*"
 typing-extensions = "^4.9.0"
 
 [tool.poetry.group.docs]


### PR DESCRIPTION
Follow-on from #51.

- Added `pytest-version` matrix entry.
- Performing a two-phase install to largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
  - Removed `pytest` from dev dependencies.
  - Updated `CONTRIBUTING.md` to specify `poetry install --all-extras`.
- Avoided duplicated definitions of sharded `coverage` file.
- Removed custom `poetry` config from project. This allows CI to work, and makes our config more standard.
  - Removed `.venv` from `.gitignore`