### PR TITLE
Added `logot.unittest` API with `LogotTestCase`

### DIFF
--- a/docs/api/logot.logged.rst
+++ b/docs/api/logot.logged.rst
@@ -7,14 +7,14 @@
 API reference
 -------------
 
-.. autofunction:: logot.logged.log
+.. autofunction:: log
 
-.. autofunction:: logot.logged.debug
+.. autofunction:: debug
 
-.. autofunction:: logot.logged.info
+.. autofunction:: info
 
-.. autofunction:: logot.logged.warning
+.. autofunction:: warning
 
-.. autofunction:: logot.logged.error
+.. autofunction:: error
 
-.. autofunction:: logot.logged.critical
+.. autofunction:: critical

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -7,10 +7,10 @@
 API reference
 -------------
 
-.. autoclass:: logot.Logot
+.. autoclass:: Logot
    :members:
 
-.. autoclass:: logot.Logged
+.. autoclass:: Logged
 
-.. autoclass:: logot.Captured
+.. autoclass:: Captured
    :members:

--- a/docs/api/logot.unittest.rst
+++ b/docs/api/logot.unittest.rst
@@ -1,0 +1,12 @@
+:mod:`logot.unittest`
+=====================
+
+.. automodule:: logot.unittest
+
+
+API reference
+-------------
+
+.. autoclass:: LogotTestCase
+   :members:
+   :exclude-members: run,debug

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,6 @@ extensions = [
     "sphinx.ext.intersphinx",
 ]
 
-autoclass_content = "both"
 autodoc_member_order = "bysource"
 autodoc_typehints = "both"
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -24,7 +24,7 @@ Installing package ``extras``
 
    pip install 'logot[pytest]'
 
-Supported 3rd-party integrations:
+Package extras for supported 3rd-party integrations:
 
 - ``pytest`` - :doc:`usage-pytest`
 

--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -11,14 +11,18 @@ Log capturing
       app.start()
       logot.wait_for(logged.info("App started"))
 
-.. note::
 
-   If using :mod:`pytest`, you can probably just use the pre-configured ``logot`` fixture included in the bundled
-   :doc:`pytest plugin </usage-pytest>` and skip manually configuring log capture. 💪
+Test framework integrations
+---------------------------
+
+Use a supported test framework integration for automatic log capturing in tests:
+
+- :doc:`/usage-pytest`
+- :doc:`/usage-unittest`
 
 
 Capturing :mod:`logging` logs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 
 The :meth:`Logot.capturing` method defaults to capturing **all** records from the root logger. Customize this with the
 ``level`` and ``logger`` arguments to :meth:`Logot.capturing`:
@@ -40,7 +44,7 @@ careful to avoid capturing duplicate logs with overlapping calls to :meth:`Logot
 .. _log-capturing-3rd-party:
 
 Capturing 3rd-party logs
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 Any 3rd-party logging library can be integrated with :mod:`logot` by sending :class:`Captured` logs to
 :meth:`Logot.capture`:

--- a/docs/usage-unittest.rst
+++ b/docs/usage-unittest.rst
@@ -10,8 +10,7 @@ during tests and can be used to make log assertions:
 
 .. code:: python
 
-   import unittest
-   from logot import Logot, logged
+   from logot import logged
    from logot.unittest import LogotTestCase
 
    class MyAppTest(LogotTestCase):

--- a/docs/usage-unittest.rst
+++ b/docs/usage-unittest.rst
@@ -3,20 +3,36 @@ Using with :mod:`unittest`
 
 .. currentmodule:: logot
 
-:mod:`logot` is compatible with any testing framework, including :mod:`unittest`:
+:mod:`logot` provides :class:`logot.unittest.LogotTestCase` for easy integration with :mod:`unittest`.
+
+The :attr:`logot <logot.unittest.LogotTestCase.logot>` attribute automatically :doc:`captures logs </log-capturing>`
+during tests and can be used to make log assertions:
 
 .. code:: python
 
    import unittest
    from logot import Logot, logged
+   from logot.unittest import LogotTestCase
 
-   class MyAppTest(unittest.TestCase):
+   class MyAppTest(LogotTestCase):
 
       def test_my_app(self) -> None:
-         with Logot().capturing() as logot:
-            app.start()
-            logot.wait_for(logged.info("App started"))
+         app.start()
+         self.logot.wait_for(logged.info("App started"))
 
 .. seealso::
 
-   See :class:`Logot` and :meth:`Logot.capturing` API reference.
+   See :mod:`logot.unittest` API reference.
+
+
+Customizing log capturing
+-------------------------
+
+Override :mod:`logot`-prefixed attributes in your :class:`logot.unittest.LogotTestCase` subclass to customize automatic
+:doc:`log capturing </log-capturing>`:
+
+.. code:: python
+
+   class MyAppTest(LogotTestCase):
+
+      logot_level = logging.WARNING

--- a/docs/usage-unittest.rst
+++ b/docs/usage-unittest.rst
@@ -3,7 +3,7 @@ Using with :mod:`unittest`
 
 .. currentmodule:: logot
 
-:mod:`logot` provides :class:`logot.unittest.LogotTestCase` for easy integration with :mod:`unittest`.
+:mod:`logot` includes :class:`logot.unittest.LogotTestCase` for easy integration with :mod:`unittest`.
 
 The :attr:`logot <logot.unittest.LogotTestCase.logot>` attribute automatically :doc:`captures logs </log-capturing>`
 during tests and can be used to make log assertions:

--- a/docs/usage-unittest.rst
+++ b/docs/usage-unittest.rst
@@ -33,5 +33,5 @@ Override :mod:`logot`-prefixed attributes in your :class:`logot.unittest.LogotTe
 .. code:: python
 
    class MyAppTest(LogotTestCase):
-
       logot_level = logging.WARNING
+      logot_logger = "app"

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+from typing import ClassVar
+from unittest import TestCase, TestResult
+
+from logot._logot import Logot
+
+
+class LogotTestCase(TestCase):
+    """
+    A :class:`unittest.TestCase` subclass with automatic :doc:`log capturing </log-capturing>`.
+    """
+
+    logot: Logot
+    """
+    An initialized :class:`logot.Logot` instance with :doc:`log capturing </log-capturing>` enabled.
+
+    Use this to make log assertions in your tests.
+    """
+
+    logot_level: ClassVar[str | int] = Logot.DEFAULT_LEVEL
+    """
+    The ``level`` used by automatic :doc:`log capturing </log-capturing>`.
+
+    .. note::
+
+        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
+    """
+
+    logot_logger: ClassVar[logging.Logger | str | None] = Logot.DEFAULT_LOGGER
+    """
+    The ``logger`` used by automatic :doc:`log capturing </log-capturing>`.
+
+    .. note::
+
+        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
+    """
+
+    logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
+    """
+    The ``timeout`` (in seconds) for initialized :class:`logot.Logot` instances.
+
+    .. note::
+
+        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
+    """
+
+    def _logot_setup(self) -> None:
+        self.logot = Logot(timeout=self.logot_timeout)
+        ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
+        ctx.__enter__()
+        self.addCleanup(ctx.__exit__, None, None, None)
+
+    def run(self, result: TestResult | None = None) -> TestResult | None:
+        self._logot_setup()
+        return super().run(result)
+
+    def debug(self) -> None:
+        self._logot_setup()
+        return super().debug()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -23,6 +23,8 @@ class LogotTestCase(TestCase):
     """
     The ``level`` used by automatic :doc:`log capturing </log-capturing>`.
 
+    Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
+
     .. note::
 
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
@@ -32,6 +34,8 @@ class LogotTestCase(TestCase):
     """
     The ``logger`` used by automatic :doc:`log capturing </log-capturing>`.
 
+    Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
+
     .. note::
 
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
@@ -39,7 +43,9 @@ class LogotTestCase(TestCase):
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """
-    The ``timeout`` (in seconds) for initialized :class:`logot.Logot` instances.
+    The ``timeout`` (in seconds) for :attr:`LogotTestCase.logot`.
+
+    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`.
 
     .. note::
 

--- a/logot/unittest.py
+++ b/logot/unittest.py
@@ -1,0 +1,10 @@
+"""
+Integration API for :mod:`unittest`.
+
+.. seealso::
+
+    See :doc:`/usage-unittest` usage guide.
+"""
+from __future__ import annotations
+
+from logot._unittest import LogotTestCase as LogotTestCase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,7 @@ source = ["logot", "tests"]
 show_missing = true
 skip_covered = true
 fail_under = 100
-exclude_lines = [
-    "pragma: no cover",
-    "raise NotImplementedError",
-    "if TYPE_CHECKING:",
-]
+exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.mypy]
 files = ["logot/**/*.py", "tests/**/*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "logot"
-version = "0.3.1"
+version = "0.3.2"
 description = "Log-based testing"
 authors = ["Dave Hall <dave@etianen.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,11 @@ source = ["logot", "tests"]
 show_missing = true
 skip_covered = true
 fail_under = 100
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]
 
 [tool.mypy]
 files = ["logot/**/*.py", "tests/**/*.py"]

--- a/tests/test_unittest.py
+++ b/tests/test_unittest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from logot import logged
+from logot.unittest import LogotTestCase
+from tests import logger
+
+
+class TestUnitTest(LogotTestCase):
+    def test_capture(self) -> None:
+        logger.info("foo bar")
+        self.logot.assert_logged(logged.info("foo bar"))
+
+    def test_debug(self) -> None:
+        TestUnitTest("test_capture").debug()


### PR DESCRIPTION
- Tweaked `sphinx` config to avoid leaking `unittest.TestCase` docs.
- Removed pointless namespacing on other API docs.

Closes #23.