### PR TITLE
Removing issue tracker link from sidebar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -159,6 +159,5 @@ Learn more about :mod:`logot` with the following guides:
    :caption: Project links
 
    GitHub repository <https://github.com/etianen/logot>
-   Issue tracker <https://github.com/etianen/logot/issues>
    Changelog <https://github.com/etianen/logot/releases>
    PyPI project <https://pypi.org/project/logot/>


### PR DESCRIPTION
The repo is already linked, and we have better things to put there.