### PR TITLE
Emphasised the synchronous assertions in docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 ``` python
 from logot import Logot, logged
 
-def test_my_app(logot: Logot) -> None:
-    app.start()
-    logot.wait_for(logged.info("App started"))
+def test_something(logot: Logot) -> None:
+    do_something()
+    logot.assert_logged(logged.info("Something was done"))
 ```
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,9 @@ Log-based testing 🪵
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
-      app.start()
-      logot.wait_for(logged.info("App started"))
+   def test_something(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.info("Something was done"))
 
 .. note::
 
@@ -22,11 +22,10 @@ Log-based testing 🪵
 Why test logging? 🤔
 --------------------
 
-Good logging ensures your code is debuggable at runtime, but why bother actually *testing* your logs? After all...
-surely the worst that can happen is your logs are a bit *wonky*? 🥴
+Good logging ensures your code is debuggable at runtime, but why bother actually *testing* your logs?
 
 Sometimes, testing logs is the only *reasonable* way to known your code has actually run correctly! This is particularly
-the case in *threaded* or *asynchronous* code where work is carried out at unpredictable times by background workers.
+the case in *threaded* or *asynchronous* code.
 
 For example, imagine the following code running in a thread:
 
@@ -45,9 +44,8 @@ For example, imagine the following code running in a thread:
 
 .. note::
 
-   It's certainly *possible* to rewrite this code in a way that can be tested without :mod:`logot`, but that often makes
-   the code less clear or more verbose. For complex threaded or asynchronous code, this can quickly become burdensome.
-   👎
+   While it's *possible* to rewrite this code in a way that can be tested without :mod:`logot`, that risks making the
+   code less clear or more verbose. For complex threaded or asynchronous code, this can quickly become burdensome. 👎
 
 Testing this code with :mod:`logot` is easy!
 
@@ -65,14 +63,15 @@ Testing this code with :mod:`logot` is easy!
 Testing threaded code
 ---------------------
 
-Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or the timeout expires:
+Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or the ``timeout`` expires:
 
 .. code:: python
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
-      app.start()
+   def test_app(logot: Logot) -> None:
+      thread = Thread(target=app.start)
+      thread.start()
       logot.wait_for(logged.info("App started"))
 
 .. note::
@@ -88,14 +87,14 @@ Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or 
 Testing asynchronous code
 -------------------------
 
-Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or the timeout expires:
+Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or the ``timeout`` expires:
 
 .. code:: python
 
    from logot import Logot, logged
 
-   async def test_my_app(logot: Logot) -> None:
-      app.start()
+   async def test_app(logot: Logot) -> None:
+      asyncio.create_task(app.start())
       await logot.await_for(logged.info("App started"))
 
 .. note::
@@ -106,29 +105,6 @@ Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or
 .. seealso::
 
    See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
-
-
-Testing synchronous code
-------------------------
-
-Use :meth:`Logot.assert_logged` to fail *immediately* if the expected logs have not arrived:
-
-.. code:: python
-
-   from logot import Logot, logged
-
-   def test_my_app(logot: Logot) -> None:
-      app.run()
-      logot.assert_logged(logged.info("App started"))
-
-.. note::
-
-   You can also use :meth:`Logot.wait_for` to test for expected logs, but since this only fails after a ``timeout``,
-   using :meth:`Logot.assert_logged` will give more immediate feedback if your test fails.
-
-.. seealso::
-
-   Use :meth:`Logot.assert_not_logged` to fail *immediately* if the expected logs *do* arrive.
 
 
 Further reading

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,8 +70,7 @@ Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or 
    from logot import Logot, logged
 
    def test_app(logot: Logot) -> None:
-      thread = Thread(target=app.start)
-      thread.start()
+      app.start()
       logot.wait_for(logged.info("App started"))
 
 .. note::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,6 +106,29 @@ Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or
    See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
 
 
+Testing synchronous code
+------------------------
+
+Use :meth:`Logot.assert_logged` to fail *immediately* if the expected logs have not arrived:
+
+.. code:: python
+
+   from logot import Logot, logged
+
+   def test_something(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.info("Something was done"))
+
+.. note::
+
+   You can also use :meth:`Logot.wait_for` to test for expected logs, but since this only fails after a ``timeout``,
+   using :meth:`Logot.assert_logged` will give more immediate feedback if your test fails.
+
+.. seealso::
+
+   Use :meth:`Logot.assert_not_logged` to fail *immediately* if the expected logs *do* arrive.
+
+
 Further reading
 ---------------
 

--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -8,8 +8,8 @@ Log capturing
 .. code:: python
 
    with Logot().capturing() as logot:
-      app.start()
-      logot.wait_for(logged.info("App started"))
+      do_something()
+      logot.assert_logged(logged.info("App started"))
 
 
 Test framework integrations
@@ -30,8 +30,8 @@ The :meth:`Logot.capturing` method defaults to capturing **all** records from th
 .. code:: python
 
    with Logot().capturing(level=logging.WARNING, logger="app") as logot:
-      app.start()
-      logot.wait_for(logged.info("App started"))
+      do_something()
+      logot.assert_logged(logged.info("App started"))
 
 For advanced use-cases, multiple :meth:`Logot.capturing` calls on the same :class:`Logot` instance are supported. Be
 careful to avoid capturing duplicate logs with overlapping calls to :meth:`Logot.capturing`!

--- a/docs/log-message-matching.rst
+++ b/docs/log-message-matching.rst
@@ -9,9 +9,9 @@ Log message matching
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
-      app.start()
-      logot.wait_for(logged.info("App %s"))
+   def test_something(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.info("Something %s done"))
 
 In this case, the ``%s`` placeholder will match *any* string!
 
@@ -19,8 +19,8 @@ In this case, the ``%s`` placeholder will match *any* string!
 Available placeholders
 ----------------------
 
-The following placeholders are available, each corresponding to a formatting option available in the stdlib
-:mod:`logging` module:
+The following placeholders are available, each corresponding to a formatting option from the stdlib :mod:`logging`
+module:
 
 ===========  ===========================================================================================================
 Placeholder  Matches

--- a/docs/log-pattern-matching.rst
+++ b/docs/log-pattern-matching.rst
@@ -4,7 +4,7 @@ Log pattern matching
 .. currentmodule:: logot
 
 :mod:`logot` makes it easy to match logs that may arrive in an unpredictable order. This is especially useful in
-*threaded* or *asynchronous* code!
+*threaded* or *asynchronous* code. 💪
 
 Compose your :mod:`logot.logged` calls with special *log pattern operators*:
 
@@ -12,7 +12,7 @@ Compose your :mod:`logot.logged` calls with special *log pattern operators*:
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
+   def test_app(logot: Logot) -> None:
       app.start()
       logot.wait_for(
          # Wait for the app to start...
@@ -41,7 +41,7 @@ Use the ``>>`` operator to wait for logs that must arrive in a *sequential* orde
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
+   def test_app(logot: Logot) -> None:
       app.start()
       logot.wait_for(
          logged.info("App started")
@@ -58,9 +58,8 @@ Use the ``&`` operator to wait for logs that must arrive in *any* order:
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
+   def test_app(logot: Logot) -> None:
       app.start()
-      other_app.start()
       logot.wait_for(
          logged.info("App started")
          & logged.info("Other app started")
@@ -76,7 +75,7 @@ Use the ``|`` operator to wait for *any* matching log pattern:
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
+   def test_app(logot: Logot) -> None:
       app.start()
       logot.wait_for(
          logged.info("App stopped")

--- a/docs/log-pattern-matching.rst
+++ b/docs/log-pattern-matching.rst
@@ -60,6 +60,7 @@ Use the ``&`` operator to wait for logs that must arrive in *any* order:
 
    def test_app(logot: Logot) -> None:
       app.start()
+      other_app.start()
       logot.wait_for(
          logged.info("App started")
          & logged.info("Other app started")

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -12,7 +12,7 @@ assertions:
 
    from logot import Logot, logged
 
-   def test_app(logot: Logot) -> None:
+   def test_something(logot: Logot) -> None:
       do_something()
       logot.assert_logged(logged.info("Something was done"))
 

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -12,9 +12,9 @@ assertions:
 
    from logot import Logot, logged
 
-   def test_my_app(logot: Logot) -> None:
-      app.start()
-      logot.wait_for(logged.info("App started"))
+   def test_app(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.info("Something was done"))
 
 
 Installing

--- a/docs/using-unittest.rst
+++ b/docs/using-unittest.rst
@@ -15,7 +15,7 @@ during tests and can be used to make log assertions:
 
    class MyAppTest(LogotTestCase):
 
-      def test_app(self) -> None:
+      def test_something(self) -> None:
          do_something()
          self.logot.assert_logged(logged.info("App started"))
 

--- a/docs/using-unittest.rst
+++ b/docs/using-unittest.rst
@@ -15,9 +15,9 @@ during tests and can be used to make log assertions:
 
    class MyAppTest(LogotTestCase):
 
-      def test_my_app(self) -> None:
-         app.start()
-         self.logot.wait_for(logged.info("App started"))
+      def test_app(self) -> None:
+         do_something()
+         self.logot.assert_logged(logged.info("App started"))
 
 
 Configuring

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -115,6 +115,28 @@ class Logot:
             # Otherwise, buffer the captured log.
             self._queue.append(captured)
 
+    def assert_logged(self, logged: Logged) -> None:
+        """
+        Fails *immediately* if the expected ``log`` pattern has not arrived.
+
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
+        :raises AssertionError: If the expected ``log`` pattern has not arrived.
+        """
+        reduced = self._reduce(logged)
+        if reduced is not None:
+            raise AssertionError(f"Not logged:\n\n{reduced}")
+
+    def assert_not_logged(self, logged: Logged) -> None:
+        """
+        Fails *immediately* if the expected ``log`` pattern **has** arrived.
+
+        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
+        :raises AssertionError: If the expected ``log`` pattern **has** arrived.
+        """
+        reduced = self._reduce(logged)
+        if reduced is None:
+            raise AssertionError(f"Logged:\n\n{logged}")
+
     def wait_for(self, logged: Logged, *, timeout: float | None = None) -> None:
         """
         Waits for the expected ``log`` pattern to arrive or the ``timeout`` to expire.
@@ -142,28 +164,6 @@ class Logot:
             await waiter.wait()
         finally:
             self._close_waiter(waiter)
-
-    def assert_logged(self, logged: Logged) -> None:
-        """
-        Fails *immediately* if the expected ``log`` pattern has not arrived.
-
-        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
-        :raises AssertionError: If the expected ``log`` pattern has not arrived.
-        """
-        reduced = self._reduce(logged)
-        if reduced is not None:
-            raise AssertionError(f"Not logged:\n\n{reduced}")
-
-    def assert_not_logged(self, logged: Logged) -> None:
-        """
-        Fails *immediately* if the expected ``log`` pattern **has** arrived.
-
-        :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
-        :raises AssertionError: If the expected ``log`` pattern **has** arrived.
-        """
-        reduced = self._reduce(logged)
-        if reduced is None:
-            raise AssertionError(f"Logged:\n\n{logged}")
 
     def clear(self) -> None:
         """

--- a/tests/test_logot.py
+++ b/tests/test_logot.py
@@ -27,6 +27,38 @@ def test_capturing() -> None:
         logger.setLevel(logging.NOTSET)
 
 
+def test_assert_logged_pass(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "foo bar"))
+    logot.assert_logged(logged.info("foo bar"))
+
+
+def test_assert_logged_fail(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "boom!"))
+    with pytest.raises(AssertionError) as ex:
+        logot.assert_logged(logged.info("foo bar"))
+    assert str(ex.value) == lines(
+        "Not logged:",
+        "",
+        "[INFO] foo bar",
+    )
+
+
+def test_assert_not_logged_pass(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "boom!"))
+    logot.assert_not_logged(logged.info("foo bar"))
+
+
+def test_assert_not_logged_fail(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "foo bar"))
+    with pytest.raises(AssertionError) as ex:
+        logot.assert_not_logged(logged.info("foo bar"))
+    assert str(ex.value) == lines(
+        "Logged:",
+        "",
+        "[INFO] foo bar",
+    )
+
+
 def test_wait_for_pass_immediate(logot: Logot) -> None:
     logot.capture(Captured("INFO", "foo bar"))
     logot.wait_for(logged.info("foo bar"))
@@ -67,38 +99,6 @@ async def test_await_for_fail(logot: Logot) -> None:
         await logot.await_for(logged.info("foo bar"), timeout=0.1)
     assert str(ex.value) == lines(
         "Not logged:",
-        "",
-        "[INFO] foo bar",
-    )
-
-
-def test_assert_logged_pass(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "foo bar"))
-    logot.assert_logged(logged.info("foo bar"))
-
-
-def test_assert_logged_fail(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "boom!"))
-    with pytest.raises(AssertionError) as ex:
-        logot.assert_logged(logged.info("foo bar"))
-    assert str(ex.value) == lines(
-        "Not logged:",
-        "",
-        "[INFO] foo bar",
-    )
-
-
-def test_assert_not_logged_pass(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "boom!"))
-    logot.assert_not_logged(logged.info("foo bar"))
-
-
-def test_assert_not_logged_fail(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "foo bar"))
-    with pytest.raises(AssertionError) as ex:
-        logot.assert_not_logged(logged.info("foo bar"))
-    assert str(ex.value) == lines(
-        "Logged:",
         "",
         "[INFO] foo bar",
     )


### PR DESCRIPTION
Although `logot.wait_for()` is _the pun_, the synchronous interface is likely the most useful to most people, and should be front-and-center in the docs.