### PR TITLE
Installing the `main` dependency group in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     # largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
     - name: Install dependencies
       run: |
-        poetry install --no-root --without main
+        poetry install --no-root
         poetry run pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
     # Run checks.
     - name: Check (ruff)


### PR DESCRIPTION
This allows better use of the lockfile for core (non-extra) dependencies.