### PR TITLE
Build matrix refactor

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,7 +1,7 @@
 inputs:
   python-version:
     type: string
-    default: "3.x"
+    default: "3.12"
 runs:
   using: composite
   steps:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,7 +1,6 @@
 inputs:
   python-version:
     type: string
-    default: "3.12"
 runs:
   using: composite
   steps:
@@ -10,7 +9,7 @@ runs:
       shell: bash
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ inputs.python-version || '3.12' }}
         cache: poetry
     # Run pre-install checks.
     - run: poetry check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,19 +7,17 @@ permissions:
 
 jobs:
   test:
-    name: test (python~=${{ matrix.python-version }}, pytest${{ matrix.pytest-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version:
-        - "3.8"
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        pytest-version:
-        - "~=7.0"
-        - "~=8.0"
+        include:
+          - python-version: "3.8"
+          - python-version: "3.9"
+          - python-version: "3.10"
+          - python-version: "3.11"
+          - python-version: "3.12"
+          - lib-versions: "pytest~=7.0"
+          - lib-versions: "pytest~=8.0"
       fail-fast: false
     env:
       COVERAGE_FILE: .coverage.python~=${{ matrix.python-version }}.pytest${{ matrix.pytest-version }}
@@ -36,9 +34,10 @@ jobs:
     # editable mode with compatible `extra` dependencies from the test matrix. This is a compromise that allows us to
     # largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
     - name: Install dependencies
-      run: |
-        poetry install --no-root
-        poetry run pip install -e .[pytest] "pytest${{ matrix.pytest-version }}"
+      run: poetry install --all-extras
+    - name: Install lib versions
+      run: poetry run pip install -e .[pytest] ${{ matrix.lib-versions }}
+      if: ${{ matrix.lib-versions }}
     # Run checks.
     - name: Check (ruff)
       run: poetry run ruff check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
           - lib-versions: "pytest~=8.0"
       fail-fast: false
     env:
-      COVERAGE_FILE: .coverage.python~=${{ matrix.python-version }}.pytest${{ matrix.pytest-version }}
+      COVERAGE_FILE: .coverage.${{ matrix.python-version }}${{ matrix.lib-versions }}
       PYTHONDEVMODE: 1
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: Build
 
 on:
-- pull_request:
-- push:
+  pull_request:
+  push:
     branches: [main]
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
-on: [pull_request]
+on:
+- pull_request:
+- push:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
We're about to add more optional dependencies, which is going to cause an explosion of build matrix combos.

This refactor means we still test every supported dependency and python version, but with less redundancy.