### PR TITLE
Splitting up sync and async wait tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,26 +1,14 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import threading
-from collections.abc import Coroutine, Generator
+from collections.abc import Generator
 from contextlib import contextmanager
-from functools import wraps
 from time import sleep
-from typing import Any, Callable
 
 from logot import Captured, Logot
-from logot._typing import P
 
 logger = logging.getLogger("logot")
-
-
-def asyncio_test(test_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
-    @wraps(test_fn)
-    def asyncio_test_wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
-        asyncio.run(test_fn(*args, **kwargs))
-
-    return asyncio_test_wrapper
 
 
 def lines(*lines: str) -> str:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from functools import wraps
+from typing import Any, Callable
+
+import pytest
+
+from logot import Captured, Logot, logged
+from logot._typing import P
+from tests import capture_soon, lines
+
+
+def asyncio_test(test_fn: Callable[P, Coroutine[Any, Any, None]]) -> Callable[P, None]:
+    @wraps(test_fn)
+    def asyncio_test_wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
+        asyncio.run(test_fn(*args, **kwargs))
+
+    return asyncio_test_wrapper
+
+
+@asyncio_test
+async def test_await_for_pass_immediate(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "foo bar"))
+    await logot.await_for(logged.info("foo bar"))
+
+
+@asyncio_test
+async def test_await_for_pass_soon(logot: Logot) -> None:
+    with capture_soon(logot, Captured("INFO", "foo bar")):
+        await logot.await_for(logged.info("foo bar"))
+
+
+@asyncio_test
+async def test_await_for_fail(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "boom!"))
+    with pytest.raises(AssertionError) as ex:
+        await logot.await_for(logged.info("foo bar"), timeout=0.1)
+    assert str(ex.value) == lines(
+        "Not logged:",
+        "",
+        "[INFO] foo bar",
+    )

--- a/tests/test_logot.py
+++ b/tests/test_logot.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 from logot import Captured, Logot, logged
-from tests import capture_soon, lines, logger
+from tests import lines, logger
 
 
 def test_capturing() -> None:
@@ -54,27 +54,6 @@ def test_assert_not_logged_fail(logot: Logot) -> None:
         logot.assert_not_logged(logged.info("foo bar"))
     assert str(ex.value) == lines(
         "Logged:",
-        "",
-        "[INFO] foo bar",
-    )
-
-
-def test_wait_for_pass_immediate(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "foo bar"))
-    logot.wait_for(logged.info("foo bar"))
-
-
-def test_wait_for_pass_soon(logot: Logot) -> None:
-    with capture_soon(logot, Captured("INFO", "foo bar")):
-        logot.wait_for(logged.info("foo bar"))
-
-
-def test_wait_for_fail(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "boom!"))
-    with pytest.raises(AssertionError) as ex:
-        logot.wait_for(logged.info("foo bar"), timeout=0.1)
-    assert str(ex.value) == lines(
-        "Not logged:",
         "",
         "[INFO] foo bar",
     )

--- a/tests/test_logot.py
+++ b/tests/test_logot.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 from logot import Captured, Logot, logged
-from tests import asyncio_test, capture_soon, lines, logger
+from tests import capture_soon, lines, logger
 
 
 def test_capturing() -> None:
@@ -73,30 +73,6 @@ def test_wait_for_fail(logot: Logot) -> None:
     logot.capture(Captured("INFO", "boom!"))
     with pytest.raises(AssertionError) as ex:
         logot.wait_for(logged.info("foo bar"), timeout=0.1)
-    assert str(ex.value) == lines(
-        "Not logged:",
-        "",
-        "[INFO] foo bar",
-    )
-
-
-@asyncio_test
-async def test_await_for_pass_immediate(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "foo bar"))
-    await logot.await_for(logged.info("foo bar"))
-
-
-@asyncio_test
-async def test_await_for_pass_soon(logot: Logot) -> None:
-    with capture_soon(logot, Captured("INFO", "foo bar")):
-        await logot.await_for(logged.info("foo bar"))
-
-
-@asyncio_test
-async def test_await_for_fail(logot: Logot) -> None:
-    logot.capture(Captured("INFO", "boom!"))
-    with pytest.raises(AssertionError) as ex:
-        await logot.await_for(logged.info("foo bar"), timeout=0.1)
     assert str(ex.value) == lines(
         "Not logged:",
         "",

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from logot import Captured, Logot, logged
+from tests import capture_soon, lines
+
+
+def test_wait_for_pass_immediate(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "foo bar"))
+    logot.wait_for(logged.info("foo bar"))
+
+
+def test_wait_for_pass_soon(logot: Logot) -> None:
+    with capture_soon(logot, Captured("INFO", "foo bar")):
+        logot.wait_for(logged.info("foo bar"))
+
+
+def test_wait_for_fail(logot: Logot) -> None:
+    logot.capture(Captured("INFO", "boom!"))
+    with pytest.raises(AssertionError) as ex:
+        logot.wait_for(logged.info("foo bar"), timeout=0.1)
+    assert str(ex.value) == lines(
+        "Not logged:",
+        "",
+        "[INFO] foo bar",
+    )


### PR DESCRIPTION
This prepares the way for swappable wait implementations (see #24)