### PR TITLE
Added swappable backends for `Logot.wait_for()` and `Logot.await_for()`

### DIFF
--- a/docs/api/logot.asyncio.rst
+++ b/docs/api/logot.asyncio.rst
@@ -1,0 +1,11 @@
+:mod:`logot.asyncio`
+====================
+
+.. automodule:: logot.asyncio
+
+
+API reference
+-------------
+
+.. autoclass:: AsyncioWaiter
+   :members:

--- a/docs/api/logot.asyncio.rst
+++ b/docs/api/logot.asyncio.rst
@@ -9,4 +9,4 @@ API reference
 
 .. autoclass:: AsyncioWaiter
    :members:
-   :exclude-members: notify,wait
+   :exclude-members: release,wait

--- a/docs/api/logot.asyncio.rst
+++ b/docs/api/logot.asyncio.rst
@@ -9,3 +9,4 @@ API reference
 
 .. autoclass:: AsyncioWaiter
    :members:
+   :exclude-members: notify,wait

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -15,12 +15,5 @@ API reference
 .. autoclass:: Captured
    :members:
 
-.. autoclass:: Waiter
-   :members:
-
 .. autoclass:: AsyncWaiter
    :members:
-
-.. autoclass:: ThreadingWaiter
-   :members:
-   :exclude-members: notify,wait

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -17,8 +17,6 @@ API reference
 
 .. autoclass:: Waiter
    :members:
-   :inherited-members:
 
 .. autoclass:: AsyncWaiter
    :members:
-   :inherited-members:

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -21,6 +21,6 @@ API reference
 .. autoclass:: AsyncWaiter
    :members:
 
-.. autoclass:: ThreadedWaiter
+.. autoclass:: ThreadingWaiter
    :members:
    :exclude-members: notify,wait

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -20,3 +20,7 @@ API reference
 
 .. autoclass:: AsyncWaiter
    :members:
+
+.. autoclass:: ThreadedWaiter
+   :members:
+   :exclude-members: notify,wait

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -14,3 +14,11 @@ API reference
 
 .. autoclass:: Captured
    :members:
+
+.. autoclass:: Waiter
+   :members:
+   :inherited-members:
+
+.. autoclass:: AsyncWaiter
+   :members:
+   :inherited-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,8 @@ Testing this code with :mod:`logot` is easy!
          logot.wait_for(logged.info("Poll finished"))
 
 
+.. _index-testing-threaded:
+
 Testing threaded code
 ---------------------
 
@@ -82,6 +84,8 @@ Use :meth:`Logot.wait_for` to pause your test until the expected logs arrive or 
 
    See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
 
+
+.. _index-testing-async:
 
 Testing asynchronous code
 -------------------------

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -57,6 +57,11 @@ Use the following CLI and :external+pytest:doc:`configuration <reference/customi
 
    Defaults to :attr:`logot.Logot.DEFAULT_ASYNC_WAITER`.
 
+.. note::
+
+   When both CLI and :external+pytest:doc:`configuration <reference/customize>` options are given, the CLI option takes
+   precidence.
+
 
 Available fixtures
 ------------------
@@ -66,24 +71,14 @@ The following fixtures are available in the :mod:`pytest` plugin:
 ``logot:`` :class:`logot.Logot`
    An initialized :class:`logot.Logot` instance with :doc:`log capturing </log-capturing>` enabled.
 
-   Use this to make log assertions in your tests.
-
 ``logot_level:`` :class:`str` | :class:`int`
    The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
-
-   Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
 
 ``logot_logger:`` :class:`str` | :data:`None`
    The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
 
-   Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
-
 ``logot_timeout:`` :class:`float`
    The default ``timeout`` (in seconds) for the ``logot`` fixture.
 
-   Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`
-
 ``logot_async_waiter:`` ``Callable`` [[], :class:`AsyncWaiter` ]
    The default ``async_waiter`` for the ``logot`` fixture.
-
-   Defaults to :attr:`logot.Logot.DEFAULT_ASYNC_WAITER`.

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -52,6 +52,16 @@ Use the following CLI and :external+pytest:doc:`configuration <reference/customi
 
    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`.
 
+``--logot-waiter-factory``, ``logot_waiter_factory``
+   The default ``waiter_factory`` for the ``logot`` fixture.
+
+   Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
+
+``--logot-awaiter-factory``, ``logot_awaiter_factory``
+   The default ``awaiter_factory`` for the ``logot`` fixture.
+
+   Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.
+
 
 Available fixtures
 ------------------
@@ -77,3 +87,13 @@ The following fixtures are available in the :mod:`pytest` plugin:
    The default ``timeout`` (in seconds) for the ``logot`` fixture.
 
    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`
+
+``logot_waiter_factory:`` ``Callable[[],`` :class:`Waiter` ``]``
+   The default ``waiter_factory`` for the ``logot`` fixture.
+
+   Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
+
+``logot_awaiter_factory:`` ``Callable[[],`` :class:`AsyncWaiter` ``]``
+   The default ``awaiter_factory`` for the ``logot`` fixture.
+
+   Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -73,12 +73,12 @@ The following fixtures are available in the :mod:`pytest` plugin:
 
    Use this to make log assertions in your tests.
 
-``logot_level:`` :class:`str` ``|`` :class:`int`
+``logot_level:`` :class:`str` | :class:`int`
    The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
 
    Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
 
-``logot_logger:`` :class:`str` ``|`` :data:`None`
+``logot_logger:`` :class:`str` | :data:`None`
    The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
 
    Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
@@ -88,12 +88,12 @@ The following fixtures are available in the :mod:`pytest` plugin:
 
    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`
 
-``logot_waiter_factory:`` ``Callable[[],`` :class:`Waiter` ``]``
+``logot_waiter_factory:`` ``Callable`` [[], :class:`Waiter` ]
    The default ``waiter_factory`` for the ``logot`` fixture.
 
    Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
 
-``logot_awaiter_factory:`` ``Callable[[],`` :class:`AsyncWaiter` ``]``
+``logot_awaiter_factory:`` ``Callable`` [[], :class:`AsyncWaiter` ]
    The default ``awaiter_factory`` for the ``logot`` fixture.
 
    Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -52,15 +52,10 @@ Use the following CLI and :external+pytest:doc:`configuration <reference/customi
 
    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`.
 
-``--logot-waiter-factory``, ``logot_waiter_factory``
-   The default ``waiter_factory`` for the ``logot`` fixture.
+``--logot-async-waiter``, ``logot_async_waiter``
+   The default ``async_waiter`` for the ``logot`` fixture.
 
-   Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
-
-``--logot-awaiter-factory``, ``logot_awaiter_factory``
-   The default ``awaiter_factory`` for the ``logot`` fixture.
-
-   Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.
+   Defaults to :attr:`logot.Logot.DEFAULT_ASYNC_WAITER`.
 
 
 Available fixtures
@@ -88,12 +83,7 @@ The following fixtures are available in the :mod:`pytest` plugin:
 
    Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`
 
-``logot_waiter_factory:`` ``Callable`` [[], :class:`Waiter` ]
-   The default ``waiter_factory`` for the ``logot`` fixture.
+``logot_async_waiter:`` ``Callable`` [[], :class:`AsyncWaiter` ]
+   The default ``async_waiter`` for the ``logot`` fixture.
 
-   Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
-
-``logot_awaiter_factory:`` ``Callable`` [[], :class:`AsyncWaiter` ]
-   The default ``awaiter_factory`` for the ``logot`` fixture.
-
-   Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.
+   Defaults to :attr:`logot.Logot.DEFAULT_ASYNC_WAITER`.

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -11,5 +11,3 @@ from logot._capture import Captured as Captured
 from logot._logged import Logged as Logged
 from logot._logot import Logot as Logot
 from logot._wait import AsyncWaiter as AsyncWaiter
-from logot._wait import ThreadingWaiter as ThreadingWaiter
-from logot._wait import Waiter as Waiter

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -11,5 +11,5 @@ from logot._capture import Captured as Captured
 from logot._logged import Logged as Logged
 from logot._logot import Logot as Logot
 from logot._wait import AsyncWaiter as AsyncWaiter
-from logot._wait import ThreadedWaiter as ThreadedWaiter
+from logot._wait import ThreadingWaiter as ThreadingWaiter
 from logot._wait import Waiter as Waiter

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -10,3 +10,6 @@ from __future__ import annotations
 from logot._capture import Captured as Captured
 from logot._logged import Logged as Logged
 from logot._logot import Logot as Logot
+from logot._wait import AsyncWaiter as AsyncWaiter
+from logot._wait import ThreadedWaiter as ThreadedWaiter
+from logot._wait import Waiter as Waiter

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -11,7 +11,7 @@ class AsyncioWaiter(AsyncWaiter):
 
     .. note::
 
-        This is the default :class:`logot.AsyncWaiter` implementation for :mod:`logot`.
+        This is the default :class:`logot.AsyncWaiter` implementation.
     """
 
     __slots__ = ("_loop", "_future")

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -6,26 +6,18 @@ from logot._wait import AsyncWaiter
 
 
 class AsyncioWaiter(AsyncWaiter):
-    __slots__ = ("_loop", "_future")
+    __slots__ = ("_loop", "_event")
 
     def __init__(self) -> None:
-        # Create an unresolved `asyncio.Future`. This will be resolved by `notify()`.
         self._loop = asyncio.get_running_loop()
-        self._future: asyncio.Future[None] = self._loop.create_future()
+        self._event = asyncio.Event()
 
     def notify(self) -> None:
-        self._loop.call_soon_threadsafe(self._resolve)
+        self._loop.call_soon_threadsafe(self._event.set)
 
     async def wait(self, *, timeout: float) -> None:
-        timer = self._loop.call_later(timeout, self._resolve)
+        timer = self._loop.call_later(timeout, self._event.set)
         try:
-            await self._future
+            await self._event.wait()
         finally:
             timer.cancel()
-
-    def _resolve(self) -> None:
-        try:
-            self._future.set_result(None)
-        except asyncio.InvalidStateError:  # pragma: no cover
-            # It's possible that the timeout and the `notify()` will both occur in the same tick of the event loop.
-            pass

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -14,18 +14,26 @@ class AsyncioWaiter(AsyncWaiter):
         This is the default :class:`logot.AsyncWaiter` implementation for :mod:`logot`.
     """
 
-    __slots__ = ("_loop", "_event")
+    __slots__ = ("_loop", "_future")
 
     def __init__(self) -> None:
+        # Create an unresolved `asyncio.Future`. This will be resolved by `notify()`.
         self._loop = asyncio.get_running_loop()
-        self._event = asyncio.Event()
+        self._future: asyncio.Future[None] = self._loop.create_future()
 
     def notify(self) -> None:
-        self._loop.call_soon_threadsafe(self._event.set)
+        self._loop.call_soon_threadsafe(self._resolve)
 
     async def wait(self, *, timeout: float) -> None:
-        timer = self._loop.call_later(timeout, self._event.set)
+        timer = self._loop.call_later(timeout, self._resolve)
         try:
-            await self._event.wait()
+            await self._future
         finally:
             timer.cancel()
+
+    def _resolve(self) -> None:
+        try:
+            self._future.set_result(None)
+        except asyncio.InvalidStateError:  # pragma: no cover
+            # It's possible that the timeout and the `notify()` will both occur in the same tick of the event loop.
+            pass

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -6,6 +6,14 @@ from logot._wait import AsyncWaiter
 
 
 class AsyncioWaiter(AsyncWaiter):
+    """
+    A :class:`logot.AsyncWaiter` implementation for :mod:`asyncio`.
+
+    .. note::
+
+        This is the default :class:`logot.AsyncWaiter` implementation for :mod:`logot`.
+    """
+
     __slots__ = ("_loop", "_event")
 
     def __init__(self) -> None:

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -17,7 +17,7 @@ class AsyncioWaiter(AsyncWaiter):
     __slots__ = ("_loop", "_future")
 
     def __init__(self) -> None:
-        # Create an unresolved `asyncio.Future`. This will be resolved by `notify()`.
+        # Create an unresolved `asyncio.Future`. This will be resolved by `release()`.
         self._loop = asyncio.get_running_loop()
         self._future: asyncio.Future[None] = self._loop.create_future()
 
@@ -35,5 +35,5 @@ class AsyncioWaiter(AsyncWaiter):
         try:
             self._future.set_result(None)
         except asyncio.InvalidStateError:  # pragma: no cover
-            # It's possible that the timeout and the `notify()` will both occur in the same tick of the event loop.
+            # It's possible that the timeout and the `release()` will both occur in the same tick of the event loop.
             pass

--- a/logot/_asyncio.py
+++ b/logot/_asyncio.py
@@ -21,7 +21,7 @@ class AsyncioWaiter(AsyncWaiter):
         self._loop = asyncio.get_running_loop()
         self._future: asyncio.Future[None] = self._loop.create_future()
 
-    def notify(self) -> None:
+    def release(self) -> None:
         self._loop.call_soon_threadsafe(self._resolve)
 
     async def wait(self, *, timeout: float) -> None:

--- a/logot/_import.py
+++ b/logot/_import.py
@@ -9,6 +9,6 @@ def import_any(module: str, name: str) -> Any:
     return getattr(module_obj, name)
 
 
-def import_name(name: str) -> Any:
+def import_any_parsed(name: str) -> Any:
     module, name = name.rsplit(".", 1)
     return import_any(module, name)

--- a/logot/_import.py
+++ b/logot/_import.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+def import_any(module: str, name: str) -> Any:
+    module_obj = import_module(module)
+    return getattr(module_obj, name)
+
+
+def import_name(name: str) -> Any:
+    module, name = name.rsplit(".", 1)
+    return import_any(module, name)

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -12,7 +12,7 @@ from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AsyncWaiterFactory, W, create_threading_waiter
+from logot._wait import AsyncWaiterFactory, W
 
 
 class Logot:
@@ -166,9 +166,11 @@ class Logot:
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
-        waiter = self._start_waiting(logged, create_threading_waiter, timeout=timeout)
-        if waiter is None:
-            return
+        with self._lock:
+            waiter = self._start_waiting(logged, Lock, timeout=timeout)
+            if waiter is None:
+                return
+            waiter.waiter.acquire()
         try:
             waiter.waiter.acquire(timeout=waiter.timeout)
         finally:
@@ -192,9 +194,10 @@ class Logot:
         """
         if awaiter_factory is None:
             awaiter_factory = self.awaiter_factory
-        waiter = self._start_waiting(logged, awaiter_factory, timeout=timeout)
-        if waiter is None:
-            return
+        with self._lock:
+            waiter = self._start_waiting(logged, awaiter_factory, timeout=timeout)
+            if waiter is None:
+                return
         try:
             await waiter.waiter.wait(timeout=waiter.timeout)
         finally:
@@ -210,24 +213,23 @@ class Logot:
     def _start_waiting(
         self, logged: Logged | None, waiter_factory: Callable[[], W], *, timeout: float | None
     ) -> _Waiter[W] | None:
-        with self._lock:
-            # If no timeout is provided, use the default timeout.
-            # Otherwise, validate and use the provided timeout.
-            if timeout is None:
-                timeout = self.timeout
-            else:
-                timeout = validate_timeout(timeout)
-            # Ensure no other waiters.
-            if self._waiter is not None:  # pragma: no cover
-                raise RuntimeError("Multiple concurrent waiters are not supported")
-            # Apply an immediate reduction.
-            logged = self._reduce(logged)
-            if logged is None:
-                return None
-            # Set a waiter.
-            waiter = self._waiter = _Waiter(logged=logged, timeout=timeout, waiter=waiter_factory())
-            # All done!
-            return waiter
+        # If no timeout is provided, use the default timeout.
+        # Otherwise, validate and use the provided timeout.
+        if timeout is None:
+            timeout = self.timeout
+        else:
+            timeout = validate_timeout(timeout)
+        # Ensure no other waiters.
+        if self._waiter is not None:  # pragma: no cover
+            raise RuntimeError("Multiple concurrent waiters are not supported")
+        # Apply an immediate reduction.
+        logged = self._reduce(logged)
+        if logged is None:
+            return None
+        # Set a waiter.
+        waiter = self._waiter = _Waiter(logged=logged, timeout=timeout, waiter=waiter_factory())
+        # All done!
+        return waiter
 
     def _stop_waiting(self, waiter: _Waiter[Any]) -> None:
         with self._lock:

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import logging
 from collections import deque
 from contextlib import AbstractContextManager
@@ -293,9 +292,10 @@ class _Handler(logging.Handler):
         self._logot.capture(captured)
 
 
-@dataclasses.dataclass()
 class _WaiterState(Generic[W]):
     __slots__ = ("logged", "timeout", "waiter")
-    logged: Logged | None
-    timeout: float
-    waiter: W
+
+    def __init__(self, *, logged: Logged | None, timeout: float, waiter: W) -> None:
+        self.logged = logged
+        self.timeout = timeout
+        self.waiter = waiter

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -27,7 +27,7 @@ class Logot:
     :param awaiter_factory: See :attr:`Logot.awaiter_factory`.
     """
 
-    __slots__ = ("timeout", "_lock", "_queue", "_waiter", "waiter_factory", "awaiter_factory")
+    __slots__ = ("timeout", "waiter_factory", "awaiter_factory", "_lock", "_queue", "_waiter")
 
     DEFAULT_LEVEL: ClassVar[str | int] = "DEBUG"
     """

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import dataclasses
 import logging
 from collections import deque
 from contextlib import AbstractContextManager
 from threading import Lock
 from types import TracebackType
-from typing import Any, Callable, ClassVar, Generic
+from typing import Callable, ClassVar
 
 from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AsyncWaiterFactory, ThreadingWaiter, W
+from logot._wait import AbstractWaiter, AsyncWaiterFactory, ThreadingWaiter, W
 
 
 class Logot:
@@ -76,7 +75,7 @@ class Logot:
         self.awaiter_factory = awaiter_factory
         self._lock = Lock()
         self._queue: deque[Captured] = deque()
-        self._waiter: _Waiter[Any] | None = None
+        self._waiter: AbstractWaiter | None = None
 
     def capturing(
         self,
@@ -122,11 +121,11 @@ class Logot:
         """
         with self._lock:
             # If there is a waiter that has not been fully reduced, attempt to reduce it.
-            if self._waiter is not None and self._waiter.logged is not None:
-                self._waiter.logged = self._waiter.logged._reduce(captured)
+            if self._waiter is not None and self._waiter._logged is not None:
+                self._waiter._logged = self._waiter._logged._reduce(captured)
                 # If the waiter has fully reduced, notify the blocked caller.
-                if self._waiter.logged is None:
-                    self._waiter.waiter.notify()
+                if self._waiter._logged is None:
+                    self._waiter.notify()
                 return
             # Otherwise, buffer the captured log.
             self._queue.append(captured)
@@ -170,7 +169,7 @@ class Logot:
         if waiter is None:
             return
         try:
-            waiter.waiter.wait(timeout=waiter.timeout)
+            waiter.wait(timeout=waiter._timeout)
         finally:
             self._stop_waiting(waiter)
 
@@ -196,7 +195,7 @@ class Logot:
         if waiter is None:
             return
         try:
-            await waiter.waiter.wait(timeout=waiter.timeout)
+            await waiter.wait(timeout=waiter._timeout)
         finally:
             self._stop_waiting(waiter)
 
@@ -209,7 +208,7 @@ class Logot:
 
     def _start_waiting(
         self, logged: Logged | None, waiter_factory: Callable[[], W], *, timeout: float | None
-    ) -> _Waiter[W] | None:
+    ) -> W | None:
         with self._lock:
             # If no timeout is provided, use the default timeout.
             # Otherwise, validate and use the provided timeout.
@@ -225,17 +224,19 @@ class Logot:
             if logged is None:
                 return None
             # Set a waiter.
-            waiter = self._waiter = _Waiter(logged=logged, timeout=timeout, waiter=waiter_factory())
+            waiter = self._waiter = waiter_factory()
+            waiter._logged = logged
+            waiter._timeout = timeout
             # All done!
             return waiter
 
-    def _stop_waiting(self, waiter: _Waiter[Any]) -> None:
+    def _stop_waiting(self, waiter: AbstractWaiter) -> None:
         with self._lock:
             # Clear the waiter.
             self._waiter = None
             # Error if the waiter logs are not fully reduced.
-            if waiter.logged is not None:
-                raise AssertionError(f"Not logged:\n\n{waiter.logged}")
+            if waiter._logged is not None:
+                raise AssertionError(f"Not logged:\n\n{waiter._logged}")
 
     def _reduce(self, logged: Logged | None) -> Logged | None:
         # Drain the queue until the log is fully reduced.
@@ -292,11 +293,3 @@ class _Handler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
         self._logot.capture(captured)
-
-
-@dataclasses.dataclass()
-class _Waiter(Generic[W]):
-    __slots__ = ("logged", "timeout", "waiter")
-    logged: Logged | None
-    timeout: float
-    waiter: W

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -122,7 +122,7 @@ class Logot:
             # If there is a waiter that has not been fully reduced, attempt to reduce it.
             if self._wait is not None and self._wait.logged is not None:
                 self._wait.logged = self._wait.logged._reduce(captured)
-                # If the waiter has fully reduced, notify the blocked caller.
+                # If the waiter has fully reduced, release the blocked caller.
                 if self._wait.logged is None:
                     self._wait.waiter.release()
                 return

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -186,7 +186,7 @@ class Logot:
 
         :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
-        :param waiter_factory: Protocol used to pause tests until expected logs arrive. Defaults to
+        :param awaiter_factory: Protocol used to pause tests until expected logs arrive. Defaults to
             :attr:`Logot.DEFAULT_AWAITER_FACTORY`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -12,7 +12,7 @@ from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AsyncWaiterFactory, ThreadingWaiter, W
+from logot._wait import AsyncWaiterFactory, W, create_threading_waiter
 
 
 class Logot:
@@ -166,11 +166,11 @@ class Logot:
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
-        waiter = self._start_waiting(logged, ThreadingWaiter, timeout=timeout)
+        waiter = self._start_waiting(logged, create_threading_waiter, timeout=timeout)
         if waiter is None:
             return
         try:
-            waiter.waiter.wait(timeout=waiter.timeout)
+            waiter.waiter.acquire(timeout=waiter.timeout)
         finally:
             self._stop_waiting(waiter)
 

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -48,12 +48,12 @@ class Logot:
 
     DEFAULT_WAITER_FACTORY: ClassVar[WaiterFactory] = ThreadingWaiter
     """
-    The default ``waiter_factory`` factory for new :class:`Logot` instances.
+    The default ``waiter_factory`` for new :class:`Logot` instances.
     """
 
     DEFAULT_AWAITER_FACTORY: ClassVar[AsyncWaiterFactory] = AsyncioWaiter
     """
-    The default ``awaiter_factory`` factory for new :class:`Logot` instances.
+    The default ``awaiter_factory`` for new :class:`Logot` instances.
     """
 
     timeout: float

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -229,13 +229,13 @@ class Logot:
             wait = self._wait = _Wait(logged=logged, timeout=timeout, waiter=waiter())
             return wait
 
-    def _stop_waiting(self, waiter: _Wait[Any]) -> None:
+    def _stop_waiting(self, wait: _Wait[Any]) -> None:
         with self._lock:
             # Clear the waiter.
             self._wait = None
             # Error if the waiter logs are not fully reduced.
-            if waiter.logged is not None:
-                raise AssertionError(f"Not logged:\n\n{waiter.logged}")
+            if wait.logged is not None:
+                raise AssertionError(f"Not logged:\n\n{wait.logged}")
 
     def _reduce(self, logged: Logged | None) -> Logged | None:
         # Drain the queue until the log is fully reduced.

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -81,8 +81,8 @@ class Logot:
         self,
         *,
         timeout: float = DEFAULT_TIMEOUT,
-        waiter_factory: Callable[[], Waiter] = ThreadingWaiter,
-        awaiter_factory: Callable[[], AsyncWaiter] = AsyncioWaiter,
+        waiter_factory: Callable[[], Waiter] = DEFAULT_WAITER_FACTORY,
+        awaiter_factory: Callable[[], AsyncWaiter] = DEFAULT_AWAITER_FACTORY,
     ) -> None:
         self.timeout = validate_timeout(timeout)
         self.waiter_factory = waiter_factory

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -11,7 +11,7 @@ from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AbstractWaiter, AsyncWaiter, ThreadedWaiter, Waiter
+from logot._wait import AbstractWaiter, AsyncWaiter, ThreadingWaiter, Waiter
 
 
 class Logot:
@@ -59,7 +59,7 @@ class Logot:
         self,
         *,
         timeout: float = DEFAULT_TIMEOUT,
-        waiter_factory: Callable[[], Waiter] = ThreadedWaiter,
+        waiter_factory: Callable[[], Waiter] = ThreadingWaiter,
         awaiter_factory: Callable[[], AsyncWaiter] = AsyncioWaiter,
     ) -> None:
         self.timeout = validate_timeout(timeout)

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -11,7 +11,7 @@ from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AsyncWaiterFactory, W, create_threading_waiter
+from logot._wait import AsyncWaiter, W, create_threading_waiter
 
 
 class Logot:
@@ -46,7 +46,7 @@ class Logot:
     The default ``timeout`` (in seconds) for new :class:`Logot` instances.
     """
 
-    DEFAULT_AWAITER_FACTORY: ClassVar[AsyncWaiterFactory] = AsyncioWaiter
+    DEFAULT_AWAITER_FACTORY: ClassVar[Callable[[], AsyncWaiter]] = AsyncioWaiter
     """
     The default ``awaiter_factory`` for new :class:`Logot` instances.
     """
@@ -58,7 +58,7 @@ class Logot:
     Defaults to :attr:`Logot.DEFAULT_TIMEOUT`.
     """
 
-    awaiter_factory: AsyncWaiterFactory
+    awaiter_factory: Callable[[], AsyncWaiter]
     """
     The default ``awaiter_factory`` for calls to :meth:`await_for`.
 
@@ -69,7 +69,7 @@ class Logot:
         self,
         *,
         timeout: float = DEFAULT_TIMEOUT,
-        awaiter_factory: AsyncWaiterFactory = DEFAULT_AWAITER_FACTORY,
+        awaiter_factory: Callable[[], AsyncWaiter] = DEFAULT_AWAITER_FACTORY,
     ) -> None:
         self.timeout = validate_timeout(timeout)
         self.awaiter_factory = awaiter_factory
@@ -178,7 +178,7 @@ class Logot:
         logged: Logged,
         *,
         timeout: float | None = None,
-        awaiter_factory: AsyncWaiterFactory | None = None,
+        awaiter_factory: Callable[[], AsyncWaiter] | None = None,
     ) -> None:
         """
         Waits *asynchronously* for the expected ``log`` pattern to arrive or the ``timeout`` to expire.

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 from collections import deque
 from contextlib import AbstractContextManager
 from threading import Lock
 from types import TracebackType
-from typing import ClassVar
+from typing import Any, Callable, ClassVar, Generic
 
 from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AbstractWaiter, AsyncWaiterFactory, ThreadingWaiter
+from logot._wait import AsyncWaiterFactory, ThreadingWaiter, W
 
 
 class Logot:
@@ -75,7 +76,7 @@ class Logot:
         self.awaiter_factory = awaiter_factory
         self._lock = Lock()
         self._queue: deque[Captured] = deque()
-        self._waiter: AbstractWaiter | None = None
+        self._waiter: _Waiter[Any] | None = None
 
     def capturing(
         self,
@@ -121,11 +122,11 @@ class Logot:
         """
         with self._lock:
             # If there is a waiter that has not been fully reduced, attempt to reduce it.
-            if self._waiter is not None and self._waiter._logged is not None:
-                self._waiter._logged = self._waiter._logged._reduce(captured)
+            if self._waiter is not None and self._waiter.logged is not None:
+                self._waiter.logged = self._waiter.logged._reduce(captured)
                 # If the waiter has fully reduced, notify the blocked caller.
-                if self._waiter._logged is None:
-                    self._waiter.notify()
+                if self._waiter.logged is None:
+                    self._waiter.waiter.notify()
                 return
             # Otherwise, buffer the captured log.
             self._queue.append(captured)
@@ -165,10 +166,11 @@ class Logot:
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
-        waiter = ThreadingWaiter()
-        timeout = self._start_waiting(logged, waiter, timeout=timeout)
+        waiter = self._start_waiting(logged, ThreadingWaiter, timeout=timeout)
+        if waiter is None:
+            return
         try:
-            waiter.wait(timeout=timeout)
+            waiter.waiter.wait(timeout=waiter.timeout)
         finally:
             self._stop_waiting(waiter)
 
@@ -190,10 +192,11 @@ class Logot:
         """
         if awaiter_factory is None:
             awaiter_factory = self.awaiter_factory
-        waiter = awaiter_factory()
-        timeout = self._start_waiting(logged, waiter, timeout=timeout)
+        waiter = self._start_waiting(logged, awaiter_factory, timeout=timeout)
+        if waiter is None:
+            return
         try:
-            await waiter.wait(timeout=timeout)
+            await waiter.waiter.wait(timeout=waiter.timeout)
         finally:
             self._stop_waiting(waiter)
 
@@ -204,7 +207,9 @@ class Logot:
         with self._lock:
             self._queue.clear()
 
-    def _start_waiting(self, logged: Logged | None, waiter: AbstractWaiter, *, timeout: float | None) -> float:
+    def _start_waiting(
+        self, logged: Logged | None, waiter_factory: Callable[[], W], *, timeout: float | None
+    ) -> _Waiter[W] | None:
         with self._lock:
             # If no timeout is provided, use the default timeout.
             # Otherwise, validate and use the provided timeout.
@@ -215,22 +220,22 @@ class Logot:
             # Ensure no other waiters.
             if self._waiter is not None:  # pragma: no cover
                 raise RuntimeError("Multiple concurrent waiters are not supported")
-            # Set a waiter.
-            waiter = self._waiter = waiter
             # Apply an immediate reduction.
-            logged = waiter._logged = self._reduce(logged)
+            logged = self._reduce(logged)
             if logged is None:
-                waiter.notify()
+                return None
+            # Set a waiter.
+            waiter = self._waiter = _Waiter(logged=logged, timeout=timeout, waiter=waiter_factory())
             # All done!
-            return timeout
+            return waiter
 
-    def _stop_waiting(self, waiter: AbstractWaiter) -> None:
+    def _stop_waiting(self, waiter: _Waiter[Any]) -> None:
         with self._lock:
             # Clear the waiter.
             self._waiter = None
             # Error if the waiter logs are not fully reduced.
-            if waiter._logged is not None:
-                raise AssertionError(f"Not logged:\n\n{waiter._logged}")
+            if waiter.logged is not None:
+                raise AssertionError(f"Not logged:\n\n{waiter.logged}")
 
     def _reduce(self, logged: Logged | None) -> Logged | None:
         # Drain the queue until the log is fully reduced.
@@ -287,3 +292,11 @@ class _Handler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
         self._logot.capture(captured)
+
+
+@dataclasses.dataclass()
+class _Waiter(Generic[W]):
+    __slots__ = ("logged", "timeout", "waiter")
+    logged: Logged | None
+    timeout: float
+    waiter: W

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -23,6 +23,8 @@ class Logot:
         See :doc:`/index` usage guide.
 
     :param timeout: See :attr:`Logot.timeout`.
+    :param waiter_factory: See :attr:`Logot.waiter_factory`.
+    :param awaiter_factory: See :attr:`Logot.awaiter_factory`.
     """
 
     __slots__ = ("timeout", "_lock", "_queue", "_waiter", "waiter_factory", "awaiter_factory")
@@ -41,19 +43,39 @@ class Logot:
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
-    The default timeout (in seconds) for new :class:`Logot` instances.
+    The default ``timeout`` (in seconds) for new :class:`Logot` instances.
+    """
+
+    DEFAULT_WAITER_FACTORY: ClassVar[Callable[[], Waiter]] = ThreadingWaiter
+    """
+    The default ``waiter_factory`` factory for new :class:`Logot` instances.
+    """
+
+    DEFAULT_AWAITER_FACTORY: ClassVar[Callable[[], AsyncWaiter]] = AsyncioWaiter
+    """
+    The default ``awaiter_factory`` factory for new :class:`Logot` instances.
     """
 
     timeout: float
     """
-    The default timeout (in seconds) for calls to :meth:`wait_for` and :meth:`await_for`.
+    The default ``timeout`` (in seconds) for calls to :meth:`wait_for` and :meth:`await_for`.
 
     Defaults to :attr:`Logot.DEFAULT_TIMEOUT`.
     """
 
     waiter_factory: Callable[[], Waiter]
+    """
+    The default ``waiter_factory`` for calls to :meth:`wait_for`.
+
+    Defaults to :attr:`Logot.DEFAULT_WAITER_FACTORY`.
+    """
 
     awaiter_factory: Callable[[], AsyncWaiter]
+    """
+    The default ``awaiter_factory`` for calls to :meth:`await_for`.
+
+    Defaults to :attr:`Logot.DEFAULT_AWAITER_FACTORY`.
+    """
 
     def __init__(
         self,

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -61,6 +61,10 @@ class Logot:
     """
     The default ``async_waiter`` for calls to :meth:`await_for`.
 
+    .. note::
+
+        This is for integration with 3rd-party asynchronous frameworks.
+
     Defaults to :attr:`Logot.DEFAULT_ASYNC_WAITER`.
     """
 
@@ -184,8 +188,8 @@ class Logot:
 
         :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
-        :param async_waiter: Protocol used to pause tests until expected logs arrive. Defaults to
-            :attr:`Logot.DEFAULT_ASYNC_WAITER`.
+        :param async_waiter: Protocol used to pause tests until expected logs arrive. This is for integration with
+            3rd-party asynchronous frameworks. Defaults to :attr:`Logot.async_waiter`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
         if async_waiter is None:

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -5,13 +5,13 @@ from collections import deque
 from contextlib import AbstractContextManager
 from threading import Lock
 from types import TracebackType
-from typing import Callable, ClassVar
+from typing import ClassVar
 
 from logot._asyncio import AsyncioWaiter
 from logot._capture import Captured
 from logot._logged import Logged
 from logot._validate import validate_level, validate_logger, validate_timeout
-from logot._wait import AbstractWaiter, AsyncWaiter, ThreadingWaiter, Waiter
+from logot._wait import AbstractWaiter, AsyncWaiterFactory, ThreadingWaiter, WaiterFactory
 
 
 class Logot:
@@ -46,12 +46,12 @@ class Logot:
     The default ``timeout`` (in seconds) for new :class:`Logot` instances.
     """
 
-    DEFAULT_WAITER_FACTORY: ClassVar[Callable[[], Waiter]] = ThreadingWaiter
+    DEFAULT_WAITER_FACTORY: ClassVar[WaiterFactory] = ThreadingWaiter
     """
     The default ``waiter_factory`` factory for new :class:`Logot` instances.
     """
 
-    DEFAULT_AWAITER_FACTORY: ClassVar[Callable[[], AsyncWaiter]] = AsyncioWaiter
+    DEFAULT_AWAITER_FACTORY: ClassVar[AsyncWaiterFactory] = AsyncioWaiter
     """
     The default ``awaiter_factory`` factory for new :class:`Logot` instances.
     """
@@ -63,14 +63,14 @@ class Logot:
     Defaults to :attr:`Logot.DEFAULT_TIMEOUT`.
     """
 
-    waiter_factory: Callable[[], Waiter]
+    waiter_factory: WaiterFactory
     """
     The default ``waiter_factory`` for calls to :meth:`wait_for`.
 
     Defaults to :attr:`Logot.DEFAULT_WAITER_FACTORY`.
     """
 
-    awaiter_factory: Callable[[], AsyncWaiter]
+    awaiter_factory: AsyncWaiterFactory
     """
     The default ``awaiter_factory`` for calls to :meth:`await_for`.
 
@@ -81,8 +81,8 @@ class Logot:
         self,
         *,
         timeout: float = DEFAULT_TIMEOUT,
-        waiter_factory: Callable[[], Waiter] = DEFAULT_WAITER_FACTORY,
-        awaiter_factory: Callable[[], AsyncWaiter] = DEFAULT_AWAITER_FACTORY,
+        waiter_factory: WaiterFactory = DEFAULT_WAITER_FACTORY,
+        awaiter_factory: AsyncWaiterFactory = DEFAULT_AWAITER_FACTORY,
     ) -> None:
         self.timeout = validate_timeout(timeout)
         self.waiter_factory = waiter_factory
@@ -171,7 +171,7 @@ class Logot:
         logged: Logged,
         *,
         timeout: float | None = None,
-        waiter_factory: Callable[[], Waiter] | None = None,
+        waiter_factory: WaiterFactory | None = None,
     ) -> None:
         """
         Waits for the expected ``log`` pattern to arrive or the ``timeout`` to expire.
@@ -196,7 +196,7 @@ class Logot:
         logged: Logged,
         *,
         timeout: float | None = None,
-        awaiter_factory: Callable[[], AsyncWaiter] | None = None,
+        awaiter_factory: AsyncWaiterFactory | None = None,
     ) -> None:
         """
         Waits *asynchronously* for the expected ``log`` pattern to arrive or the ``timeout`` to expire.

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -178,6 +178,8 @@ class Logot:
 
         :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
+        :param waiter_factory: Protocol used to pause tests until expected logs arrive. Defaults to
+            :attr:`Logot.DEFAULT_WAITER_FACTORY`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
         if waiter_factory is None:
@@ -201,6 +203,8 @@ class Logot:
 
         :param logged: The expected :doc:`log pattern </log-pattern-matching>`.
         :param timeout: How long to wait (in seconds) before failing the test. Defaults to :attr:`Logot.timeout`.
+        :param waiter_factory: Protocol used to pause tests until expected logs arrive. Defaults to
+            :attr:`Logot.DEFAULT_AWAITER_FACTORY`.
         :raises AssertionError: If the expected ``log`` pattern does not arrive within ``timeout`` seconds.
         """
         if awaiter_factory is None:

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from pkgutil import resolve_name
 from typing import Any, Callable
 
 import pytest
 
+from logot._import import import_name
 from logot._logot import Logot
 from logot._typing import T
 from logot._wait import AsyncWaiter
@@ -88,7 +88,7 @@ def logot_async_waiter(request: pytest.FixtureRequest) -> Callable[[], AsyncWait
     """
     The default `async_waiter` for the `logot` fixture.
     """
-    return _get_option(request, name="async_waiter", parser=resolve_name, default=Logot.DEFAULT_ASYNC_WAITER)
+    return _get_option(request, name="async_waiter", parser=import_name, default=Logot.DEFAULT_ASYNC_WAITER)
 
 
 def get_qualname(name: str) -> str:
@@ -123,5 +123,5 @@ def _get_option(request: pytest.FixtureRequest, *, name: str, parser: Callable[[
     # Parse and return the value.
     try:
         return parser(value)
-    except ValueError as ex:
-        raise pytest.UsageError(f"Invalid {qualname}: {ex}")
+    except Exception as ex:
+        raise pytest.UsageError(f"Invalid {qualname}: {ex}") from ex

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -123,5 +123,5 @@ def _get_option(request: pytest.FixtureRequest, *, name: str, parser: Callable[[
     # Parse and return the value.
     try:
         return parser(value)
-    except Exception as ex:
+    except ValueError as ex:
         raise pytest.UsageError(f"Invalid {qualname}: {ex}")

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -8,7 +8,7 @@ import pytest
 
 from logot._logot import Logot
 from logot._typing import T
-from logot._wait import AsyncWaiterFactory
+from logot._wait import AsyncWaiter
 
 MISSING: Any = object()
 
@@ -52,7 +52,7 @@ def logot(
     logot_level: str | int,
     logot_logger: str | None,
     logot_timeout: float,
-    logot_awaiter_factory: AsyncWaiterFactory,
+    logot_awaiter_factory: Callable[[], AsyncWaiter],
 ) -> Generator[Logot, None, None]:
     """
     An initialized `logot.Logot` instance with log capturing enabled.
@@ -90,7 +90,7 @@ def logot_timeout(request: pytest.FixtureRequest) -> float:
 
 
 @pytest.fixture(scope="session")
-def logot_awaiter_factory(request: pytest.FixtureRequest) -> AsyncWaiterFactory:
+def logot_awaiter_factory(request: pytest.FixtureRequest) -> Callable[[], AsyncWaiter]:
     """
     The default `awaiter_factory` for `logot`.
     """

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -139,5 +139,5 @@ def _get_option(request: pytest.FixtureRequest, *, name: str, parser: Callable[[
     # Parse and return the value.
     try:
         return parser(value)
-    except (ValueError, TypeError) as ex:
+    except Exception as ex:
         raise pytest.UsageError(f"Invalid {qualname}: {ex}")

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -36,12 +36,6 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
     _add_option(
         parser,
         group,
-        name="waiter_factory",
-        help="The default `waiter_factory` for `logot`",
-    )
-    _add_option(
-        parser,
-        group,
         name="async_waiter",
         help="The default `async_waiter` for `logot`",
     )

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 import pytest
 
-from logot._import import import_name
+from logot._import import import_any_parsed
 from logot._logot import Logot
 from logot._typing import T
 from logot._wait import AsyncWaiter
@@ -88,7 +88,7 @@ def logot_async_waiter(request: pytest.FixtureRequest) -> Callable[[], AsyncWait
     """
     The default `async_waiter` for the `logot` fixture.
     """
-    return _get_option(request, name="async_waiter", parser=import_name, default=Logot.DEFAULT_ASYNC_WAITER)
+    return _get_option(request, name="async_waiter", parser=import_any_parsed, default=Logot.DEFAULT_ASYNC_WAITER)
 
 
 def get_qualname(name: str) -> str:

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -42,8 +42,8 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
     _add_option(
         parser,
         group,
-        name="awaiter_factory",
-        help="The default `awaiter_factory` for `logot`",
+        name="async_waiter",
+        help="The default `async_waiter` for `logot`",
     )
 
 
@@ -52,14 +52,14 @@ def logot(
     logot_level: str | int,
     logot_logger: str | None,
     logot_timeout: float,
-    logot_awaiter_factory: Callable[[], AsyncWaiter],
+    logot_async_waiter: Callable[[], AsyncWaiter],
 ) -> Generator[Logot, None, None]:
     """
     An initialized `logot.Logot` instance with log capturing enabled.
     """
     logot = Logot(
         timeout=logot_timeout,
-        awaiter_factory=logot_awaiter_factory,
+        async_waiter=logot_async_waiter,
     )
     with logot.capturing(level=logot_level, logger=logot_logger) as logot:
         yield logot
@@ -90,11 +90,11 @@ def logot_timeout(request: pytest.FixtureRequest) -> float:
 
 
 @pytest.fixture(scope="session")
-def logot_awaiter_factory(request: pytest.FixtureRequest) -> Callable[[], AsyncWaiter]:
+def logot_async_waiter(request: pytest.FixtureRequest) -> Callable[[], AsyncWaiter]:
     """
-    The default `awaiter_factory` for `logot`.
+    The default `async_waiter` for `logot`.
     """
-    return _get_option(request, name="awaiter_factory", parser=resolve_name, default=Logot.DEFAULT_AWAITER_FACTORY)
+    return _get_option(request, name="async_waiter", parser=resolve_name, default=Logot.DEFAULT_ASYNC_WAITER)
 
 
 def get_qualname(name: str) -> str:

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -8,7 +8,7 @@ import pytest
 
 from logot._logot import Logot
 from logot._typing import T
-from logot._wait import AsyncWaiterFactory, WaiterFactory
+from logot._wait import AsyncWaiterFactory
 
 MISSING: Any = object()
 
@@ -52,7 +52,6 @@ def logot(
     logot_level: str | int,
     logot_logger: str | None,
     logot_timeout: float,
-    logot_waiter_factory: WaiterFactory,
     logot_awaiter_factory: AsyncWaiterFactory,
 ) -> Generator[Logot, None, None]:
     """
@@ -60,7 +59,6 @@ def logot(
     """
     logot = Logot(
         timeout=logot_timeout,
-        waiter_factory=logot_waiter_factory,
         awaiter_factory=logot_awaiter_factory,
     )
     with logot.capturing(level=logot_level, logger=logot_logger) as logot:
@@ -89,14 +87,6 @@ def logot_timeout(request: pytest.FixtureRequest) -> float:
     The default `timeout` (in seconds) for `logot`.
     """
     return _get_option(request, name="timeout", parser=float, default=Logot.DEFAULT_TIMEOUT)
-
-
-@pytest.fixture(scope="session")
-def logot_waiter_factory(request: pytest.FixtureRequest) -> WaiterFactory:
-    """
-    The default `waiter_factory` for `logot`.
-    """
-    return _get_option(request, name="waiter_factory", parser=resolve_name, default=Logot.DEFAULT_WAITER_FACTORY)
 
 
 @pytest.fixture(scope="session")

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -31,13 +31,13 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
         parser,
         group,
         name="timeout",
-        help="The default `timeout` (in seconds) for `logot`",
+        help="The default `timeout` (in seconds) for the `logot` fixture",
     )
     _add_option(
         parser,
         group,
         name="async_waiter",
-        help="The default `async_waiter` for `logot`",
+        help="The default `async_waiter` for the `logot` fixture",
     )
 
 
@@ -78,7 +78,7 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
 @pytest.fixture(scope="session")
 def logot_timeout(request: pytest.FixtureRequest) -> float:
     """
-    The default `timeout` (in seconds) for `logot`.
+    The default `timeout` (in seconds) for the `logot` fixture.
     """
     return _get_option(request, name="timeout", parser=float, default=Logot.DEFAULT_TIMEOUT)
 
@@ -86,7 +86,7 @@ def logot_timeout(request: pytest.FixtureRequest) -> float:
 @pytest.fixture(scope="session")
 def logot_async_waiter(request: pytest.FixtureRequest) -> Callable[[], AsyncWaiter]:
     """
-    The default `async_waiter` for `logot`.
+    The default `async_waiter` for the `logot` fixture.
     """
     return _get_option(request, name="async_waiter", parser=resolve_name, default=Logot.DEFAULT_ASYNC_WAITER)
 

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, Callable
+from typing import Callable
 
 import pytest
 
 from logot._import import import_any_parsed
 from logot._logot import Logot
-from logot._typing import T
+from logot._typing import MISSING, T
 from logot._wait import AsyncWaiter
-
-MISSING: Any = object()
 
 
 def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginManager) -> None:

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TypeVar
+from typing import Any, TypeVar
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec as ParamSpec
@@ -12,3 +12,5 @@ else:
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+MISSING: Any = object()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar
+from typing import Callable, ClassVar
 from unittest import TestCase, TestResult
 
 from logot._logot import Logot
-from logot._wait import AsyncWaiterFactory
+from logot._wait import AsyncWaiter
 
 
 class LogotTestCase(TestCase):
@@ -53,7 +53,7 @@ class LogotTestCase(TestCase):
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
-    logot_awaiter_factory: ClassVar[AsyncWaiterFactory] = Logot.DEFAULT_AWAITER_FACTORY
+    logot_awaiter_factory: ClassVar[Callable[[], AsyncWaiter]] = Logot.DEFAULT_AWAITER_FACTORY
     """
     The default ``awaiter_factory`` for :attr:`LogotTestCase.logot`.
 

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 from unittest import TestCase, TestResult
 
 from logot._logot import Logot
-from logot._wait import AsyncWaiterFactory, WaiterFactory
+from logot._wait import AsyncWaiterFactory
 
 
 class LogotTestCase(TestCase):
@@ -53,13 +53,6 @@ class LogotTestCase(TestCase):
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
-    logot_waiter_factory: ClassVar[WaiterFactory] = Logot.DEFAULT_WAITER_FACTORY
-    """
-    The default ``waiter_factory`` for :attr:`LogotTestCase.logot`.
-
-    Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
-    """
-
     logot_awaiter_factory: ClassVar[AsyncWaiterFactory] = Logot.DEFAULT_AWAITER_FACTORY
     """
     The default ``awaiter_factory`` for :attr:`LogotTestCase.logot`.
@@ -70,7 +63,6 @@ class LogotTestCase(TestCase):
     def _logot_setup(self) -> None:
         self.logot = Logot(
             timeout=self.__class__.logot_timeout,
-            waiter_factory=self.__class__.logot_waiter_factory,
             awaiter_factory=self.__class__.logot_awaiter_factory,
         )
         ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 from unittest import TestCase, TestResult
 
 from logot._logot import Logot
+from logot._wait import AsyncWaiterFactory, WaiterFactory
 
 
 class LogotTestCase(TestCase):
@@ -52,8 +53,26 @@ class LogotTestCase(TestCase):
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
+    logot_waiter_factory: ClassVar[WaiterFactory] = Logot.DEFAULT_WAITER_FACTORY
+    """
+    The default ``waiter_factory`` for :attr:`LogotTestCase.logot`.
+
+    Defaults to :attr:`logot.Logot.DEFAULT_WAITER_FACTORY`.
+    """
+
+    logot_awaiter_factory: ClassVar[AsyncWaiterFactory] = Logot.DEFAULT_AWAITER_FACTORY
+    """
+    The default ``awaiter_factory`` for :attr:`LogotTestCase.logot`.
+
+    Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.
+    """
+
     def _logot_setup(self) -> None:
-        self.logot = Logot(timeout=self.logot_timeout)
+        self.logot = Logot(
+            timeout=self.__class__.logot_timeout,
+            waiter_factory=self.__class__.logot_waiter_factory,
+            awaiter_factory=self.__class__.logot_awaiter_factory,
+        )
         ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
         ctx.__enter__()
         self.addCleanup(ctx.__exit__, None, None, None)

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -53,17 +53,17 @@ class LogotTestCase(TestCase):
         Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
-    logot_awaiter_factory: ClassVar[Callable[[], AsyncWaiter]] = Logot.DEFAULT_AWAITER_FACTORY
+    logot_async_waiter: ClassVar[Callable[[], AsyncWaiter]] = Logot.DEFAULT_ASYNC_WAITER
     """
-    The default ``awaiter_factory`` for :attr:`LogotTestCase.logot`.
+    The default ``async_waiter`` for :attr:`LogotTestCase.logot`.
 
-    Defaults to :attr:`logot.Logot.DEFAULT_AWAITER_FACTORY`.
+    Defaults to :attr:`logot.Logot.DEFAULT_ASYNC_WAITER`.
     """
 
     def _logot_setup(self) -> None:
         self.logot = Logot(
             timeout=self.__class__.logot_timeout,
-            awaiter_factory=self.__class__.logot_awaiter_factory,
+            async_waiter=self.__class__.logot_async_waiter,
         )
         ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
         ctx.__enter__()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -25,10 +25,6 @@ class LogotTestCase(TestCase):
     The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
 
     Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
-
-    .. note::
-
-        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
     logot_logger: ClassVar[logging.Logger | str | None] = Logot.DEFAULT_LOGGER
@@ -36,10 +32,6 @@ class LogotTestCase(TestCase):
     The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
 
     Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
-
-    .. note::
-
-        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
@@ -47,10 +39,6 @@ class LogotTestCase(TestCase):
     The default ``timeout`` (in seconds) for :attr:`LogotTestCase.logot`.
 
     Defaults to :attr:`logot.Logot.DEFAULT_TIMEOUT`.
-
-    .. note::
-
-        Override this in subclasses to configure automatic :doc:`log capturing </log-capturing>`.
     """
 
     logot_async_waiter: ClassVar[Callable[[], AsyncWaiter]] = Logot.DEFAULT_ASYNC_WAITER

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from threading import Lock
 from typing import Callable, Protocol, TypeVar
 
 from logot._typing import TypeAlias
@@ -13,6 +14,13 @@ class AbstractWaiter(Protocol):
 
 
 W = TypeVar("W", bound=AbstractWaiter)
+
+
+def create_threading_waiter() -> Lock:
+    # Create an already-acquired lock. This will be released by `release()`.
+    lock = Lock()
+    lock.acquire()
+    return lock
 
 
 class AsyncWaiter(ABC):

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -4,11 +4,16 @@ from abc import ABC, abstractmethod
 from threading import Lock
 from typing import Callable, TypeVar
 
+from logot._logged import Logged
 from logot._typing import TypeAlias
 
 
 class AbstractWaiter(ABC):
-    __slots__ = ()
+    __slots__ = ("_logged", "_timeout")
+
+    # These protected attrs are populated by `Logot._start_waiting()`.
+    _logged: Logged | None
+    _timeout: float
 
     @abstractmethod
     def notify(self) -> None:

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -43,7 +43,7 @@ class AsyncWaiter(ABC):
     @abstractmethod
     async def wait(self, *, timeout: float) -> None:
         """
-        Waits *asynchronously* for :meth:`notify` to be called or the ``timeout`` to expire.
+        Waits *asynchronously* for :meth:`release` to be called or the ``timeout`` to expire.
 
         :param timeout: How long to wait (in seconds) before resuming.
         """

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import Callable, Protocol, TypeVar
-
-from logot._typing import TypeAlias
+from typing import Protocol, TypeVar
 
 
 class Waiter(Protocol):
@@ -50,6 +48,3 @@ class AsyncWaiter(ABC):
         :param timeout: How long to wait (in seconds) before resuming.
         """
         raise NotImplementedError
-
-
-AsyncWaiterFactory: TypeAlias = Callable[[], AsyncWaiter]

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -76,6 +76,14 @@ class AsyncWaiter(AbstractWaiter):
 
 
 class ThreadedWaiter(Waiter):
+    """
+    A :class:`logot.Waiter` implementation for :mod:`threading`.
+
+    .. note::
+
+        This is the default :class:`logot.Waiter` implementation for :mod:`logot`.
+    """
+
     __slots__ = ("_lock",)
 
     def __init__(self) -> None:

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from threading import Lock
+from typing import Callable
 
 from logot._logged import Logged
+from logot._typing import TypeAlias
 
 
 class AbstractWaiter(ABC):
@@ -46,6 +48,9 @@ class Waiter(AbstractWaiter):
         raise NotImplementedError
 
 
+WaiterFactory: TypeAlias = Callable[[], Waiter]
+
+
 class AsyncWaiter(AbstractWaiter):
     """
     Protocol used by :meth:`Logot.await_for` to pause tests until expected logs arrive.
@@ -73,6 +78,9 @@ class AsyncWaiter(AbstractWaiter):
         :param timeout: How long to wait (in seconds) before resuming.
         """
         raise NotImplementedError
+
+
+AsyncWaiterFactory: TypeAlias = Callable[[], AsyncWaiter]
 
 
 class ThreadingWaiter(Waiter):

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -20,6 +20,11 @@ class AbstractWaiter(ABC):
 class Waiter(AbstractWaiter):
     """
     Protocol used by :meth:`Logot.wait_for` to pause tests until expected logs arrive.
+
+    .. note::
+
+        This class is for integration with :ref:`3rd-party threading frameworks <index-testing-threaded>`. It is
+        not generally used when writing tests.
     """
 
     __slots__ = ()
@@ -44,6 +49,11 @@ class Waiter(AbstractWaiter):
 class AsyncWaiter(AbstractWaiter):
     """
     Protocol used by :meth:`Logot.await_for` to pause tests until expected logs arrive.
+
+    .. note::
+
+        This class is for integration with :ref:`3rd-party asynchronous frameworks <index-testing-async>`. It is
+        not generally used when writing tests.
     """
 
     __slots__ = ()

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -19,7 +19,7 @@ class AbstractWaiter(ABC):
 
 class Waiter(AbstractWaiter):
     """
-    The protocol used by :meth:`Logot.wait_for` to pause tests until expected logs arrive.
+    Protocol used by :meth:`Logot.wait_for` to pause tests until expected logs arrive.
     """
 
     __slots__ = ()
@@ -43,7 +43,7 @@ class Waiter(AbstractWaiter):
 
 class AsyncWaiter(AbstractWaiter):
     """
-    The protocol used by :meth:`Logot.await_for` to pause tests until expected logs arrive.
+    Protocol used by :meth:`Logot.await_for` to pause tests until expected logs arrive.
     """
 
     __slots__ = ()

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -16,9 +16,6 @@ class AbstractWaiter(ABC):
     def notify(self) -> None:
         raise NotImplementedError
 
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}()"
-
 
 class Waiter(AbstractWaiter):
     """

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from threading import Event
+from threading import Lock
 
 from logot._logged import Logged
 
@@ -76,13 +76,15 @@ class AsyncWaiter(AbstractWaiter):
 
 
 class ThreadedWaiter(Waiter):
-    __slots__ = ("_event",)
+    __slots__ = ("_lock",)
 
     def __init__(self) -> None:
-        self._event = Event()
+        # Create an already-acquired lock. This will be released by `notify()`.
+        self._lock = Lock()
+        self._lock.acquire()
 
     def notify(self) -> None:
-        self._event.set()
+        self._lock.release()
 
     def wait(self, *, timeout: float) -> None:
-        self._event.wait(timeout=timeout)
+        self._lock.acquire(timeout=timeout)

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -75,7 +75,7 @@ class AsyncWaiter(AbstractWaiter):
         raise NotImplementedError
 
 
-class ThreadedWaiter(Waiter):
+class ThreadingWaiter(Waiter):
     """
     A :class:`logot.Waiter` implementation for :mod:`threading`.
 

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -16,19 +16,11 @@ class AbstractWaiter(Protocol):
 W = TypeVar("W", bound=AbstractWaiter)
 
 
-class ThreadingWaiter:
-    __slots__ = ("_lock",)
-
-    def __init__(self) -> None:
-        # Create an already-acquired lock. This will be released by `notify()`.
-        self._lock = Lock()
-        self._lock.acquire()
-
-    def release(self) -> None:
-        self._lock.release()
-
-    def wait(self, *, timeout: float) -> None:
-        self._lock.acquire(timeout=timeout)
+def create_threading_waiter() -> Lock:
+    # Create an already-acquired lock. This will be released by `release()`.
+    lock = Lock()
+    lock.acquire()
+    return lock
 
 
 class AsyncWaiter(ABC):

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -7,13 +7,13 @@ from typing import Callable, Protocol, TypeVar
 from logot._typing import TypeAlias
 
 
-class AbstractWaiter(Protocol):
+class Waiter(Protocol):
     @abstractmethod
     def release(self) -> None:
         raise NotImplementedError
 
 
-W = TypeVar("W", bound=AbstractWaiter)
+W = TypeVar("W", bound=Waiter)
 
 
 def create_threading_waiter() -> Lock:

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from threading import Lock
 from typing import Callable, Protocol, TypeVar
 
 from logot._typing import TypeAlias
@@ -14,13 +13,6 @@ class AbstractWaiter(Protocol):
 
 
 W = TypeVar("W", bound=AbstractWaiter)
-
-
-def create_threading_waiter() -> Lock:
-    # Create an already-acquired lock. This will be released by `release()`.
-    lock = Lock()
-    lock.acquire()
-    return lock
 
 
 class AsyncWaiter(ABC):

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -2,21 +2,20 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from threading import Lock
-from typing import Callable
+from typing import Callable, TypeVar
 
-from logot._logged import Logged
 from logot._typing import TypeAlias
 
 
 class AbstractWaiter(ABC):
-    __slots__ = ("_logged",)
-
-    # This protected attr is populated by `Logot._start_waiting`.
-    _logged: Logged | None
+    __slots__ = ()
 
     @abstractmethod
     def notify(self) -> None:
         raise NotImplementedError
+
+
+W = TypeVar("W", bound=AbstractWaiter)
 
 
 class ThreadingWaiter(AbstractWaiter):

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -27,14 +27,14 @@ class Waiter(AbstractWaiter):
     @abstractmethod
     def notify(self) -> None:
         """
-        Notifies the test waiting on :meth:`Waiter.wait` to resume immediately.
+        Notifies the test waiting on :meth:`wait` to resume immediately.
         """
         raise NotImplementedError
 
     @abstractmethod
     def wait(self, *, timeout: float) -> None:
         """
-        Waits for :meth:`Waiter.notify` to be called or the ``timeout`` to expire.
+        Waits for :meth:`notify` to be called or the ``timeout`` to expire.
 
         :param timeout: How long to wait (in seconds) before resuming.
         """
@@ -51,14 +51,14 @@ class AsyncWaiter(AbstractWaiter):
     @abstractmethod
     def notify(self) -> None:
         """
-        Notifies the test waiting on :meth:`AsyncWaiter.wait` to resume immediately.
+        Notifies the test waiting on :meth:`wait` to resume immediately.
         """
         raise NotImplementedError
 
     @abstractmethod
     async def wait(self, *, timeout: float) -> None:
         """
-        Waits *asynchronously* for :meth:`AsyncWaiter.notify` to be called or the ``timeout`` to expire.
+        Waits *asynchronously* for :meth:`notify` to be called or the ``timeout`` to expire.
 
         :param timeout: How long to wait (in seconds) before resuming.
         """

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -16,6 +16,9 @@ class AbstractWaiter(ABC):
     def notify(self) -> None:
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
 
 class Waiter(AbstractWaiter):
     __slots__ = ()

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -22,7 +22,7 @@ class AbstractWaiter(ABC):
 
 class Waiter(AbstractWaiter):
     """
-    A
+    The
     """
 
     __slots__ = ()
@@ -31,6 +31,8 @@ class Waiter(AbstractWaiter):
     def notify(self) -> None:
         """
         Notifies the :class:`Waiter` that the test should be resumed.
+
+        The test waiting on :meth:`wait` will resume.
         """
         raise NotImplementedError
 

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -27,8 +27,8 @@ class AsyncWaiter(ABC):
 
     .. note::
 
-        This class is for integration with :ref:`3rd-party asynchronous frameworks <index-testing-async>`. It is
-        not generally used when writing tests.
+        This class is for integration with 3rd-party asynchronous frameworks. It is not generally used when writing
+        tests.
     """
 
     __slots__ = ()
@@ -36,7 +36,7 @@ class AsyncWaiter(ABC):
     @abstractmethod
     def release(self) -> None:
         """
-        Notifies the test waiting on :meth:`wait` to resume immediately.
+        Releases the test waiting on :meth:`wait`, allowing it to resume immediately.
         """
         raise NotImplementedError
 

--- a/logot/_wait.py
+++ b/logot/_wait.py
@@ -22,7 +22,7 @@ class AbstractWaiter(ABC):
 
 class Waiter(AbstractWaiter):
     """
-    The
+    The protocol used by :meth:`Logot.wait_for` to pause tests until expected logs arrive.
     """
 
     __slots__ = ()
@@ -30,16 +30,14 @@ class Waiter(AbstractWaiter):
     @abstractmethod
     def notify(self) -> None:
         """
-        Notifies the :class:`Waiter` that the test should be resumed.
-
-        The test waiting on :meth:`wait` will resume.
+        Notifies the test waiting on :meth:`Waiter.wait` to resume immediately.
         """
         raise NotImplementedError
 
     @abstractmethod
     def wait(self, *, timeout: float) -> None:
         """
-        Waits for :meth:`notify` to be called or the ``timeout`` to expire.
+        Waits for :meth:`Waiter.notify` to be called or the ``timeout`` to expire.
 
         :param timeout: How long to wait (in seconds) before resuming.
         """
@@ -47,19 +45,26 @@ class Waiter(AbstractWaiter):
 
 
 class AsyncWaiter(AbstractWaiter):
+    """
+    The protocol used by :meth:`Logot.await_for` to pause tests until expected logs arrive.
+    """
+
     __slots__ = ()
 
     @abstractmethod
     def notify(self) -> None:
         """
-        Notifies the waiter that the :doc:`log pattern </log-pattern-matching>` has been fully matched.
-
-        The waiting test case will be resumed.
+        Notifies the test waiting on :meth:`AsyncWaiter.wait` to resume immediately.
         """
         raise NotImplementedError
 
     @abstractmethod
     async def wait(self, *, timeout: float) -> None:
+        """
+        Waits *asynchronously* for :meth:`AsyncWaiter.notify` to be called or the ``timeout`` to expire.
+
+        :param timeout: How long to wait (in seconds) before resuming.
+        """
         raise NotImplementedError
 
 

--- a/logot/asyncio.py
+++ b/logot/asyncio.py
@@ -1,0 +1,10 @@
+"""
+Integration API for :mod:`asyncio`.
+
+.. seealso::
+
+    See :ref:`index-testing-async` usage guide.
+"""
+from __future__ import annotations
+
+from logot._asyncio import AsyncioWaiter as AsyncioWaiter

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from logot._import import import_any, import_any_parsed
+
+
+def test_import_any() -> None:
+    assert import_any(__name__, "test_import_any") is test_import_any
+
+
+def test_import_any_parsed() -> None:
+    assert import_any_parsed(f"{__name__}.test_import_any_parsed") is test_import_any_parsed

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from shlex import quote
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
 from logot import Logot
 from logot._pytest import get_optname, get_qualname
-from logot._wait import AsyncWaiterFactory
+from logot._wait import AsyncWaiter
 from logot.asyncio import AsyncioWaiter
 
 
@@ -84,5 +84,5 @@ def test_timeout_cli(pytester: pytest.Pytester) -> None:
     assert_fixture_cli(pytester, "timeout", "boom!", passed=False)
 
 
-def test_awaiter_factory_default(logot_awaiter_factory: AsyncWaiterFactory) -> None:
+def test_awaiter_factory_default(logot_awaiter_factory: Callable[[], AsyncWaiter]) -> None:
     assert logot_awaiter_factory is AsyncioWaiter

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -117,14 +117,8 @@ def test_waiter_factory_cli(pytester: pytest.Pytester) -> None:
             assert logot_waiter_factory is ThreadingWaiter
         """
     )
-    pytester.makeini(
-        """
-        [pytest]
-        logot_waiter_factory = logot.ThreadingWaiter
-        """
-    )
     # Run the pytest.
-    result = pytester.runpytest()
+    result = pytester.runpytest("--logot-waiter-factory=logot.ThreadingWaiter")
     result.assert_outcomes(passed=1)
 
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextvars import ContextVar
 from shlex import quote
 from typing import Any, Callable
 
@@ -7,81 +8,76 @@ import pytest
 
 from logot import Logot
 from logot._pytest import get_optname, get_qualname
+from logot._typing import MISSING
 from logot._wait import AsyncWaiter
 from logot.asyncio import AsyncioWaiter
 
+EXPECTED_VAR: ContextVar[Any] = ContextVar(f"{__name__}.EXPECTED_VAR")
 
-def assert_fixture_ini(pytester: pytest.Pytester, name: str, value: Any, *, passed: bool = True) -> None:
+
+def assert_fixture_config(
+    pytester: pytest.Pytester,
+    name: str,
+    value: Any,
+    *,
+    expected: Any = MISSING,
+    passed: bool = True,
+) -> None:
     qualname = get_qualname(name)
     pytester.makepyfile(
         f"""
-        def test_{name}({qualname}):
-            assert {qualname} == {value!r}
-        """
-    )
-    pytester.makeini(
-        f"""
-        [pytest]
-        {qualname} = {value}
-        """
-    )
-    # Run the pytest.
-    result = pytester.runpytest()
-    result.assert_outcomes(passed=int(passed), errors=int(not passed))
+        from tests.test_pytest import EXPECTED_VAR
 
-
-def assert_fixture_cli(pytester: pytest.Pytester, name: str, value: Any, *, passed: bool = True) -> None:
-    qualname = get_qualname(name)
-    pytester.makepyfile(
-        f"""
         def test_{name}({qualname}):
-            assert {qualname} == {value!r}
+            assert {qualname} == EXPECTED_VAR.get()
         """
     )
-    # Run the pytest.
-    result = pytester.runpytest(f"{get_optname(name)}={quote(str(value))}")
-    result.assert_outcomes(
-        passed=int(passed),
-        errors=int(not passed),
-    )
+    # Set the expected `ContextVar`.
+    if expected is MISSING:
+        expected = value
+    expected_token = EXPECTED_VAR.set(expected)
+    try:
+        # Run the pytest with a CLI option.
+        result = pytester.runpytest(f"{get_optname(name)}={quote(str(value))}")
+        result.assert_outcomes(passed=int(passed), errors=int(not passed))
+        # Run the pytest with an INI option.
+        pytester.makeini(
+            f"""
+            [pytest]
+            {qualname} = {value}
+            """
+        )
+        # Run the pytest.
+        result = pytester.runpytest()
+        result.assert_outcomes(passed=int(passed), errors=int(not passed))
+    finally:
+        # Reset the expected `ContextVar`.
+        EXPECTED_VAR.reset(expected_token)
 
 
 def test_level_default(logot_level: str | int) -> None:
     assert logot_level == Logot.DEFAULT_LEVEL
 
 
-def test_level_ini(pytester: pytest.Pytester) -> None:
-    assert_fixture_ini(pytester, "level", "INFO")
-
-
-def test_level_cli(pytester: pytest.Pytester) -> None:
-    assert_fixture_cli(pytester, "level", "INFO")
+def test_level_config(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "level", "INFO")
 
 
 def test_logger_default(logot_logger: str | int) -> None:
     assert logot_logger == Logot.DEFAULT_LOGGER
 
 
-def test_logger_ini(pytester: pytest.Pytester) -> None:
-    assert_fixture_ini(pytester, "logger", "logot")
-
-
-def test_logger_cli(pytester: pytest.Pytester) -> None:
-    assert_fixture_cli(pytester, "logger", "logot")
+def test_logger_config(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "logger", "logot")
 
 
 def test_timeout_default(logot_timeout: float) -> None:
     assert logot_timeout == Logot.DEFAULT_TIMEOUT
 
 
-def test_timeout_ini(pytester: pytest.Pytester) -> None:
-    assert_fixture_ini(pytester, "timeout", 9999.0)
-    assert_fixture_ini(pytester, "timeout", "boom!", passed=False)
-
-
-def test_timeout_cli(pytester: pytest.Pytester) -> None:
-    assert_fixture_cli(pytester, "timeout", 9999.0)
-    assert_fixture_cli(pytester, "timeout", "boom!", passed=False)
+def test_timeout_config(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "timeout", 9999.0)
+    assert_fixture_config(pytester, "timeout", "boom!", passed=False)
 
 
 def test_async_waiter_default(logot_async_waiter: Callable[[], AsyncWaiter]) -> None:

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -84,5 +84,5 @@ def test_timeout_cli(pytester: pytest.Pytester) -> None:
     assert_fixture_cli(pytester, "timeout", "boom!", passed=False)
 
 
-def test_awaiter_factory_default(logot_awaiter_factory: Callable[[], AsyncWaiter]) -> None:
-    assert logot_awaiter_factory is AsyncioWaiter
+def test_async_waiter_default(logot_async_waiter: Callable[[], AsyncWaiter]) -> None:
+    assert logot_async_waiter is AsyncioWaiter

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -88,5 +88,45 @@ def test_waiter_factory_default(logot_waiter_factory: WaiterFactory) -> None:
     assert logot_waiter_factory is ThreadingWaiter
 
 
+def test_waiter_factory_ini(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(
+        """
+        from logot import ThreadingWaiter
+
+        def test_waiter_factory(logot_waiter_factory):
+            assert logot_waiter_factory is ThreadingWaiter
+        """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        logot_waiter_factory = logot.ThreadingWaiter
+        """
+    )
+    # Run the pytest.
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_waiter_factory_cli(pytester: pytest.Pytester) -> None:
+    pytester.makepyfile(
+        """
+        from logot import ThreadingWaiter
+
+        def test_waiter_factory(logot_waiter_factory):
+            assert logot_waiter_factory is ThreadingWaiter
+        """
+    )
+    pytester.makeini(
+        """
+        [pytest]
+        logot_waiter_factory = logot.ThreadingWaiter
+        """
+    )
+    # Run the pytest.
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=1)
+
+
 def test_awaiter_factory_default(logot_awaiter_factory: AsyncWaiterFactory) -> None:
     assert logot_awaiter_factory is AsyncioWaiter

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -5,9 +5,9 @@ from typing import Any
 
 import pytest
 
-from logot import Logot, ThreadingWaiter
+from logot import Logot
 from logot._pytest import get_optname, get_qualname
-from logot._wait import AsyncWaiterFactory, WaiterFactory
+from logot._wait import AsyncWaiterFactory
 from logot.asyncio import AsyncioWaiter
 
 
@@ -82,44 +82,6 @@ def test_timeout_ini(pytester: pytest.Pytester) -> None:
 def test_timeout_cli(pytester: pytest.Pytester) -> None:
     assert_fixture_cli(pytester, "timeout", 9999.0)
     assert_fixture_cli(pytester, "timeout", "boom!", passed=False)
-
-
-def test_waiter_factory_default(logot_waiter_factory: WaiterFactory) -> None:
-    assert logot_waiter_factory is ThreadingWaiter
-
-
-def test_waiter_factory_ini(pytester: pytest.Pytester) -> None:
-    pytester.makepyfile(
-        """
-        from logot import ThreadingWaiter
-
-        def test_waiter_factory(logot_waiter_factory):
-            assert logot_waiter_factory is ThreadingWaiter
-        """
-    )
-    pytester.makeini(
-        """
-        [pytest]
-        logot_waiter_factory = logot.ThreadingWaiter
-        """
-    )
-    # Run the pytest.
-    result = pytester.runpytest()
-    result.assert_outcomes(passed=1)
-
-
-def test_waiter_factory_cli(pytester: pytest.Pytester) -> None:
-    pytester.makepyfile(
-        """
-        from logot import ThreadingWaiter
-
-        def test_waiter_factory(logot_waiter_factory):
-            assert logot_waiter_factory is ThreadingWaiter
-        """
-    )
-    # Run the pytest.
-    result = pytester.runpytest("--logot-waiter-factory=logot.ThreadingWaiter")
-    result.assert_outcomes(passed=1)
 
 
 def test_awaiter_factory_default(logot_awaiter_factory: AsyncWaiterFactory) -> None:

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -59,7 +59,7 @@ def test_level_default(logot_level: str | int) -> None:
     assert logot_level == Logot.DEFAULT_LEVEL
 
 
-def test_level_config(pytester: pytest.Pytester) -> None:
+def test_level_config_pass(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "level", "INFO")
 
 
@@ -67,7 +67,7 @@ def test_logger_default(logot_logger: str | int) -> None:
     assert logot_logger == Logot.DEFAULT_LOGGER
 
 
-def test_logger_config(pytester: pytest.Pytester) -> None:
+def test_logger_config_pass(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "logger", "logot")
 
 
@@ -75,10 +75,21 @@ def test_timeout_default(logot_timeout: float) -> None:
     assert logot_timeout == Logot.DEFAULT_TIMEOUT
 
 
-def test_timeout_config(pytester: pytest.Pytester) -> None:
+def test_timeout_config_pass(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "timeout", 9999.0)
+
+
+def test_timeout_config_fail(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "timeout", "boom!", passed=False)
 
 
 def test_async_waiter_default(logot_async_waiter: Callable[[], AsyncWaiter]) -> None:
     assert logot_async_waiter is AsyncioWaiter
+
+
+def test_async_waiter_config_pass(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "async_waiter", "logot.asyncio.AsyncioWaiter", expected=AsyncioWaiter)
+
+
+def test_async_waiter_config_fail(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "async_waiter", "boom!", passed=False)

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -5,8 +5,10 @@ from typing import Any
 
 import pytest
 
-from logot import Logot
+from logot import Logot, ThreadingWaiter
 from logot._pytest import get_optname, get_qualname
+from logot._wait import AsyncWaiterFactory, WaiterFactory
+from logot.asyncio import AsyncioWaiter
 
 
 def assert_fixture_ini(pytester: pytest.Pytester, name: str, value: Any, *, passed: bool = True) -> None:
@@ -80,3 +82,11 @@ def test_timeout_ini(pytester: pytest.Pytester) -> None:
 def test_timeout_cli(pytester: pytest.Pytester) -> None:
     assert_fixture_cli(pytester, "timeout", 9999.0)
     assert_fixture_cli(pytester, "timeout", "boom!", passed=False)
+
+
+def test_waiter_factory_default(logot_waiter_factory: WaiterFactory) -> None:
+    assert logot_waiter_factory is ThreadingWaiter
+
+
+def test_awaiter_factory_default(logot_awaiter_factory: AsyncWaiterFactory) -> None:
+    assert logot_awaiter_factory is AsyncioWaiter


### PR DESCRIPTION
- Refactored protected hidden attrs on `AbstractWaiter` to a separate private `_Wait` class.
-  Refactored `AbtractWaiter` to a `Protocol` to allow direct implementation by `Lock`.
- Added an optimized fast-path for log patterns that can be reduced immediately without waiting.
- Improve `pytest` tests to allow for more complex expected values.

See #79, #24 