### PR TITLE
Added swappable backends for `Logot.capturing()`

### DIFF
--- a/docs/api/logot.asyncio.rst
+++ b/docs/api/logot.asyncio.rst
@@ -8,5 +8,3 @@ API reference
 -------------
 
 .. autoclass:: AsyncioWaiter
-   :members:
-   :exclude-members: release,wait

--- a/docs/api/logot.logging.rst
+++ b/docs/api/logot.logging.rst
@@ -1,0 +1,10 @@
+:mod:`logot.logging`
+====================
+
+.. automodule:: logot.logging
+
+
+API reference
+-------------
+
+.. autoclass:: LoggingCapturer

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -12,9 +12,6 @@ API reference
 
 .. autoclass:: Logged
 
-.. autoclass:: Capturer
-   :members:
-
 .. autoclass:: Captured
    :members:
 

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -12,6 +12,9 @@ API reference
 
 .. autoclass:: Logged
 
+.. autoclass:: Capturer
+   :members:
+
 .. autoclass:: Captured
    :members:
 

--- a/docs/api/logot.rst
+++ b/docs/api/logot.rst
@@ -10,10 +10,13 @@ API reference
 .. autoclass:: Logot
    :members:
 
-.. autoclass:: Logged
+.. autoclass:: Capturer
+   :members:
 
 .. autoclass:: Captured
    :members:
+
+.. autoclass:: Logged
 
 .. autoclass:: AsyncWaiter
    :members:

--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -21,6 +21,8 @@ Use a supported test framework integration for automatic log capturing in tests:
 - :doc:`/using-unittest`
 
 
+.. _log-capturing-logging:
+
 Capturing :mod:`logging` logs
 -----------------------------
 

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -47,6 +47,11 @@ Use the following CLI and :external+pytest:doc:`configuration <reference/customi
 
    Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
 
+``--logot-capturer``, ``logot_capturer``
+   The default ``capturer`` for the ``logot`` fixture.
+
+   Defaults to :attr:`logot.Logot.DEFAULT_CAPTURER`.
+
 ``--logot-timeout``, ``logot_timeout``
    The default ``timeout`` (in seconds) for the ``logot`` fixture.
 
@@ -76,6 +81,9 @@ The following fixtures are available in the :mod:`pytest` plugin:
 
 ``logot_logger:`` :class:`str` | :data:`None`
    The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
+
+``logot_capturer:`` ``Callable`` [[], :class:`Capturer` ]
+   The default ``capturer`` for the ``logot`` fixture.
 
 ``logot_timeout:`` :class:`float`
    The default ``timeout`` (in seconds) for the ``logot`` fixture.

--- a/docs/using-unittest.rst
+++ b/docs/using-unittest.rst
@@ -29,7 +29,7 @@ Override ``logot``-prefixed attributes in your test case to configure the
 .. code:: python
 
    class MyAppTest(LogotTestCase):
-      logot_level = logging.WARNING
+      logot_level = "WARNING"
       logot_logger = "app"
       logot_timeout = 10.0
 

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -9,6 +9,5 @@ from __future__ import annotations
 
 from logot._capture import Captured as Captured
 from logot._logged import Logged as Logged
-from logot._logot import Capturer as Capturer
 from logot._logot import Logot as Logot
 from logot._wait import AsyncWaiter as AsyncWaiter

--- a/logot/__init__.py
+++ b/logot/__init__.py
@@ -9,5 +9,6 @@ from __future__ import annotations
 
 from logot._capture import Captured as Captured
 from logot._logged import Logged as Logged
+from logot._logot import Capturer as Capturer
 from logot._logot import Logot as Logot
 from logot._wait import AsyncWaiter as AsyncWaiter

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -1,0 +1,42 @@
+# from __future__ import annotations
+
+
+# class _Capturing:
+#     __slots__ = ("_logot", "_handler", "_logger", "_prev_levelno")
+
+#     def __init__(self, logot: Logot, handler: logging.Handler, *, logger: logging.Logger) -> None:
+#         self._logot = logot
+#         self._handler = handler
+#         self._logger = logger
+
+#     def __enter__(self) -> Logot:
+#         # If the logger is less verbose than the handler, force it to the necessary verboseness.
+#         self._prev_levelno = self._logger.level
+#         if self._handler.level < self._logger.level:
+#             self._logger.setLevel(self._handler.level)
+#         # Add the handler.
+#         self._logger.addHandler(self._handler)
+#         return self._logot
+
+#     def __exit__(
+#         self,
+#         exc_type: type[BaseException] | None,
+#         exc_value: BaseException | None,
+#         traceback: TracebackType | None,
+#     ) -> None:
+#         # Remove the handler.
+#         self._logger.removeHandler(self._handler)
+#         # Restore the previous level.
+#         self._logger.setLevel(self._prev_levelno)
+
+
+# class _Handler(logging.Handler):
+#     __slots__ = ("_logot",)
+
+#     def __init__(self, level: str | int, logot: Logot) -> None:
+#         super().__init__(level)
+#         self._logot = logot
+
+#     def emit(self, record: logging.LogRecord) -> None:
+#         captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
+#         self._logot.capture(captured)

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -7,6 +7,14 @@ from logot._logot import Capturer, Logot
 
 
 class LoggingCapturer(Capturer):
+    """
+    A :class:`logot.Capturer` implementation for :mod:`logging`.
+
+    .. note::
+
+        This is the default :class:`logot.Capturer` implementation.
+    """
+
     __slots__ = ("_logger", "_handler", "_prev_levelno")
 
     def start_capturing(self, logot: Logot, /, *, level: str | int, logger: str | None) -> None:

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -1,42 +1,41 @@
-# from __future__ import annotations
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+
+from logot._capture import Captured
+from logot._logot import Logot
 
 
-# class _Capturing:
-#     __slots__ = ("_logot", "_handler", "_logger", "_prev_levelno")
-
-#     def __init__(self, logot: Logot, handler: logging.Handler, *, logger: logging.Logger) -> None:
-#         self._logot = logot
-#         self._handler = handler
-#         self._logger = logger
-
-#     def __enter__(self) -> Logot:
-#         # If the logger is less verbose than the handler, force it to the necessary verboseness.
-#         self._prev_levelno = self._logger.level
-#         if self._handler.level < self._logger.level:
-#             self._logger.setLevel(self._handler.level)
-#         # Add the handler.
-#         self._logger.addHandler(self._handler)
-#         return self._logot
-
-#     def __exit__(
-#         self,
-#         exc_type: type[BaseException] | None,
-#         exc_value: BaseException | None,
-#         traceback: TracebackType | None,
-#     ) -> None:
-#         # Remove the handler.
-#         self._logger.removeHandler(self._handler)
-#         # Restore the previous level.
-#         self._logger.setLevel(self._prev_levelno)
+def capture_logging(
+    logot: Logot,
+    *,
+    level: str | int = Logot.DEFAULT_LEVEL,
+    logger: str | None = Logot.DEFAULT_LOGGER,
+) -> Generator[None, None, None]:
+    logger = logging.getLogger(logger)
+    handler = _Handler(level, logot)
+    # If the logger is less verbose than the handler, force it to the necessary verboseness.
+    prev_levelno = logger.level
+    if handler.level < logger.level:
+        logger.setLevel(handler.level)
+    # Add the handler.
+    logger.addHandler(handler)
+    try:
+        yield
+    finally:
+        # Remove the handler and restore the previous level.
+        logger.removeHandler(handler)
+        logger.setLevel(prev_levelno)
 
 
-# class _Handler(logging.Handler):
-#     __slots__ = ("_logot",)
+class _Handler(logging.Handler):
+    __slots__ = ("_logot",)
 
-#     def __init__(self, level: str | int, logot: Logot) -> None:
-#         super().__init__(level)
-#         self._logot = logot
+    def __init__(self, level: str | int, logot: Logot) -> None:
+        super().__init__(level)
+        self._logot = logot
 
-#     def emit(self, record: logging.LogRecord) -> None:
-#         captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
-#         self._logot.capture(captured)
+    def emit(self, record: logging.LogRecord) -> None:
+        captured = Captured(record.levelname, record.getMessage(), levelno=record.levelno)
+        self._logot.capture(captured)

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -1,34 +1,28 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
-from contextlib import contextmanager
 
 from logot._capture import Captured
-from logot._logot import Logot
+from logot._logot import Capturer, Logot
 
 
-@contextmanager
-def capture_logging(
-    logot: Logot,
-    *,
-    level: str | int = Logot.DEFAULT_LEVEL,
-    logger: str | None = Logot.DEFAULT_LOGGER,
-) -> Generator[None, None, None]:
-    logger = logging.getLogger(logger)
-    handler = _Handler(level, logot)
-    # If the logger is less verbose than the handler, force it to the necessary verboseness.
-    prev_levelno = logger.level
-    if handler.level < logger.level:
-        logger.setLevel(handler.level)
-    # Add the handler.
-    logger.addHandler(handler)
-    try:
-        yield
-    finally:
+class LoggingCapturer(Capturer):
+    __slots__ = ("_logger", "_handler", "_prev_levelno")
+
+    def start_capturing(self, logot: Logot, /, *, level: str | int, logger: str | None) -> None:
+        logger = self._logger = logging.getLogger(logger)
+        handler = self._handler = _Handler(level, logot)
+        # If the logger is less verbose than the handler, force it to the necessary verboseness.
+        self._prev_levelno = logger.level
+        if handler.level < logger.level:
+            logger.setLevel(handler.level)
+        # Add the handler.
+        logger.addHandler(handler)
+
+    def stop_capturing(self) -> None:
         # Remove the handler and restore the previous level.
-        logger.removeHandler(handler)
-        logger.setLevel(prev_levelno)
+        self._logger.removeHandler(self._handler)
+        self._logger.setLevel(self._prev_levelno)
 
 
 class _Handler(logging.Handler):

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Generator
+from contextlib import contextmanager
 
 from logot._capture import Captured
 from logot._logot import Logot
 
 
+@contextmanager
 def capture_logging(
     logot: Logot,
     *,

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -123,7 +123,7 @@ class Logot:
             :attr:`Logot.DEFAULT_LEVEL`.
         :param logger: A logger or logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
         """
-        with contextmanager(capturer)(self, *args, **kwargs):
+        with capturer(self, *args, **kwargs):
             yield self
 
     def capture(self, captured: Captured) -> None:
@@ -275,7 +275,7 @@ class Logot:
         return f"Logot(timeout={self.timeout!r}, async_waiter={self.async_waiter!r})"
 
 
-Capturer: TypeAlias = Callable[Concatenate[Logot, P], Generator[None, None, None]]
+Capturer: TypeAlias = Callable[Concatenate[Logot, P], AbstractContextManager[None]]
 
 
 class _Wait(Generic[W]):

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -50,6 +50,8 @@ class Logot:
     The default ``async_waiter`` for new :class:`Logot` instances.
     """
 
+    DEFAULT_CAPTURER: ClassVar[Capturer[Any]] = LazyCallable("logot.logging", "capture_logging")
+
     timeout: float
     """
     The default ``timeout`` (in seconds) for calls to :meth:`wait_for` and :meth:`await_for`.
@@ -102,7 +104,7 @@ class Logot:
     @contextmanager
     def capturing(
         self,
-        capturer: Capturer[Any] = LazyCallable("logot.logging", "capture_logging"),
+        capturer: Capturer[Any] = DEFAULT_CAPTURER,
         /,
         *args: Any,
         **kwargs: Any,

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -40,7 +40,7 @@ class Logot:
     This is the root logger.
     """
 
-    DEFAULT_CAPTURER: ClassVar[Capturer[Any]] = LazyCallable("logot.logging", "capture_logging")
+    DEFAULT_CAPTURER: ClassVar[Capturer[...]] = LazyCallable("logot.logging", "capture_logging")
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
@@ -104,7 +104,7 @@ class Logot:
     @contextmanager
     def capturing(
         self,
-        capturer: Capturer[Any] = DEFAULT_CAPTURER,
+        capturer: Capturer[...] = DEFAULT_CAPTURER,
         /,
         *args: Any,
         **kwargs: Any,

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -295,7 +295,7 @@ class Capturer(ABC):
         """
         Starts capturing logs for the given :class:`Logot`.
 
-        Captured logs should be converted to a :class:`Captured` log and sent to :meth:`Logot.capture`.
+        Captured logs should be converted to a :class:`Captured` instance and sent to :meth:`Logot.capture`.
 
         :param logot: The :class:`Logot` instance.
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`).

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -62,7 +62,7 @@ class Logot:
 
     .. note::
 
-        This is for integration with 3rd-party logging frameworks.
+        This is for integration with :ref:`3rd-party logging frameworks <log-capturing-3rd-party>`.
 
     Defaults to :attr:`Logot.DEFAULT_CAPTURER`.
     """
@@ -119,8 +119,8 @@ class Logot:
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
             :attr:`Logot.DEFAULT_LEVEL`.
         :param logger: A logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
-        :param capturer: Protocol used to capture logs. This is for integration with 3rd-party logging frameworks.
-            Defaults to :attr:`Logot.capturer`.
+        :param capturer: Protocol used to capture logs. This is for integration with
+            :ref:`3rd-party logging frameworks <log-capturing-3rd-party>`. Defaults to :attr:`Logot.capturer`.
         """
         if capturer is None:
             capturer = self.capturer
@@ -285,7 +285,8 @@ class Capturer(ABC):
 
     .. note::
 
-        This class is for integration with 3rd-party logging frameworks. It is not generally used when writing tests.
+        This class is for integration with :ref:`3rd-party logging frameworks <log-capturing-3rd-party>`. It is not
+        generally used when writing tests.
     """
 
     __slots__ = ()

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -29,6 +29,9 @@ class Logot:
     __slots__ = ("capturer", "timeout", "async_waiter", "_lock", "_queue", "_wait")
 
     DEFAULT_CAPTURER: ClassVar[Callable[[], Capturer]] = LazyCallable("logot.logging", "LoggingCapturer")
+    """
+    The default ``capturer`` for new :class:`Logot` instances.
+    """
 
     DEFAULT_LEVEL: ClassVar[str | int] = "DEBUG"
     """

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -118,7 +118,7 @@ class Logot:
 
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
             :attr:`Logot.DEFAULT_LEVEL`.
-        :param logger: A logger or logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
+        :param logger: A logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
         :param capturer: Protocol used to capture logs. This is for integration with 3rd-party logging frameworks.
             Defaults to :attr:`Logot.capturer`.
         """
@@ -280,14 +280,34 @@ class Logot:
 
 
 class Capturer(ABC):
+    """
+    Protocol used by :meth:`Logot.capturing` to capture logs.
+
+    .. note::
+
+        This class is for integration with 3rd-party logging frameworks. It is not generally used when writing tests.
+    """
+
     __slots__ = ()
 
     @abstractmethod
     def start_capturing(self, logot: Logot, /, *, level: str | int, logger: str | None) -> None:
+        """
+        Starts capturing logs for the given :class:`Logot`.
+
+        Captured logs should be converted to a :class:`Captured` log and sent to :meth:`Logot.capture`.
+
+        :param logot: The :class:`Logot` instance.
+        :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`).
+        :param logger: A logger name to capture logs from.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def stop_capturing(self) -> None:
+        """
+        Stops capturing logs.
+        """
         raise NotImplementedError
 
 

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -43,17 +43,17 @@ class Logot:
 
     DEFAULT_CAPTURER: ClassVar[Callable[[], Capturer]] = LazyCallable("logot.logging", "LoggingCapturer")
     """
-    The default ``capturer`` for new :class:`Logot` instances.
+    The default :attr:`capturer` for new :class:`Logot` instances.
     """
 
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
-    The default ``timeout`` (in seconds) for new :class:`Logot` instances.
+    The default :attr:`timeout` (in seconds) for new :class:`Logot` instances.
     """
 
     DEFAULT_ASYNC_WAITER: ClassVar[Callable[[], AsyncWaiter]] = LazyCallable("logot.asyncio", "AsyncioWaiter")
     """
-    The default ``async_waiter`` for new :class:`Logot` instances.
+    The default :attr:`async_waiter` for new :class:`Logot` instances.
     """
 
     capturer: Callable[[], Capturer]

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -22,16 +22,12 @@ class Logot:
 
         See :doc:`/index` usage guide.
 
+    :param capturer: See :attr:`Logot.capturer`.
     :param timeout: See :attr:`Logot.timeout`.
     :param async_waiter: See :attr:`Logot.async_waiter`.
     """
 
     __slots__ = ("capturer", "timeout", "async_waiter", "_lock", "_queue", "_wait")
-
-    DEFAULT_CAPTURER: ClassVar[Callable[[], Capturer]] = LazyCallable("logot.logging", "LoggingCapturer")
-    """
-    The default ``capturer`` for new :class:`Logot` instances.
-    """
 
     DEFAULT_LEVEL: ClassVar[str | int] = "DEBUG"
     """
@@ -45,6 +41,11 @@ class Logot:
     This is the root logger.
     """
 
+    DEFAULT_CAPTURER: ClassVar[Callable[[], Capturer]] = LazyCallable("logot.logging", "LoggingCapturer")
+    """
+    The default ``capturer`` for new :class:`Logot` instances.
+    """
+
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
     The default ``timeout`` (in seconds) for new :class:`Logot` instances.
@@ -56,6 +57,11 @@ class Logot:
     """
 
     capturer: Callable[[], Capturer]
+    """
+    The default ``capturer`` used by :meth:`capturing`.
+
+    Defaults to :attr:`Logot.DEFAULT_CAPTURER`.
+    """
 
     timeout: float
     """
@@ -91,10 +97,10 @@ class Logot:
 
     def capturing(
         self,
-        capturer: Callable[[], Capturer] | None = None,
-        /,
+        *,
         level: str | int = DEFAULT_LEVEL,
         logger: str | None = DEFAULT_LOGGER,
+        capturer: Callable[[], Capturer] | None = None,
     ) -> AbstractContextManager[Logot]:
         """
         Captures logs emitted at the given ``level`` by the given ``logger`` for the duration of the context.

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -60,6 +60,10 @@ class Logot:
     """
     The default ``capturer`` used by :meth:`capturing`.
 
+    .. note::
+
+        This is for integration with 3rd-party logging frameworks.
+
     Defaults to :attr:`Logot.DEFAULT_CAPTURER`.
     """
 
@@ -115,6 +119,8 @@ class Logot:
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
             :attr:`Logot.DEFAULT_LEVEL`.
         :param logger: A logger or logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
+        :param capturer: Protocol used to capture logs. This is for integration with 3rd-party logging frameworks.
+            Defaults to :attr:`Logot.capturer`.
         """
         if capturer is None:
             capturer = self.capturer

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -40,6 +40,8 @@ class Logot:
     This is the root logger.
     """
 
+    DEFAULT_CAPTURER: ClassVar[Capturer[Any]] = LazyCallable("logot.logging", "capture_logging")
+
     DEFAULT_TIMEOUT: ClassVar[float] = 3.0
     """
     The default ``timeout`` (in seconds) for new :class:`Logot` instances.
@@ -49,8 +51,6 @@ class Logot:
     """
     The default ``async_waiter`` for new :class:`Logot` instances.
     """
-
-    DEFAULT_CAPTURER: ClassVar[Capturer[Any]] = LazyCallable("logot.logging", "capture_logging")
 
     timeout: float
     """

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, Callable
+from typing import Callable
 
 import pytest
 
@@ -51,7 +51,7 @@ def logot(
     logot_logger: str | None,
     logot_timeout: float,
     logot_async_waiter: Callable[[], AsyncWaiter],
-    logot_capturer: Capturer[Any],
+    logot_capturer: Capturer[...],
 ) -> Generator[Logot, None, None]:
     """
     An initialized `logot.Logot` instance with log capturing enabled.
@@ -81,7 +81,7 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
 
 
 @pytest.fixture(scope="session")
-def logot_capturer(request: pytest.FixtureRequest) -> Capturer[Any]:
+def logot_capturer(request: pytest.FixtureRequest) -> Capturer[...]:
     """
     The `capturer` used for automatic log capturing.
     """

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
         parser,
         group,
         name="capturer",
-        help="The default `capturer` for the `logot` fixture",
+        help="The `capturer` used for automatic log capturing.",
     )
     _add_option(
         parser,
@@ -67,7 +67,7 @@ def logot(
 @pytest.fixture(scope="session")
 def logot_level(request: pytest.FixtureRequest) -> str | int:
     """
-    The level used for automatic log capturing.
+    The `level` used for automatic log capturing.
     """
     return _get_option(request, name="level", parser=str, default=Logot.DEFAULT_LEVEL)
 
@@ -75,9 +75,17 @@ def logot_level(request: pytest.FixtureRequest) -> str | int:
 @pytest.fixture(scope="session")
 def logot_logger(request: pytest.FixtureRequest) -> str | None:
     """
-    The logger used for automatic log capturing.
+    The `logger` used for automatic log capturing.
     """
     return _get_option(request, name="logger", parser=str, default=Logot.DEFAULT_LOGGER)
+
+
+@pytest.fixture(scope="session")
+def logot_capturer(request: pytest.FixtureRequest) -> Capturer[Any]:
+    """
+    The `capturer` used for automatic log capturing.
+    """
+    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 @pytest.fixture(scope="session")
@@ -94,14 +102,6 @@ def logot_async_waiter(request: pytest.FixtureRequest) -> Callable[[], AsyncWait
     The default `async_waiter` for the `logot` fixture.
     """
     return _get_option(request, name="async_waiter", parser=import_any_parsed, default=Logot.DEFAULT_ASYNC_WAITER)
-
-
-@pytest.fixture(scope="session")
-def logot_capturer(request: pytest.FixtureRequest) -> Capturer[Any]:
-    """
-    The default `capturer` for the `logot` fixture.
-    """
-    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 def get_qualname(name: str) -> str:

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -57,6 +57,8 @@ def logot(
     An initialized `logot.Logot` instance with log capturing enabled.
     """
     logot = Logot(capturer=logot_capturer, timeout=logot_timeout, async_waiter=logot_async_waiter)
+    # Start automatic log capturing.
+    # Use the `Capturer` directly, rather than `Logot.capturing()`, to save a few CPU cycles.
     capturer_obj = logot_capturer()
     capturer_obj.start_capturing(logot, level=logot_level, logger=logot_logger)
     yield logot

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -47,9 +47,9 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
 
 @pytest.fixture()
 def logot(
-    logot_capturer: Callable[[], Capturer],
     logot_level: str | int,
     logot_logger: str | None,
+    logot_capturer: Callable[[], Capturer],
     logot_timeout: float,
     logot_async_waiter: Callable[[], AsyncWaiter],
 ) -> Generator[Logot, None, None]:
@@ -59,14 +59,6 @@ def logot(
     logot = Logot(capturer=logot_capturer, timeout=logot_timeout, async_waiter=logot_async_waiter)
     with logot.capturing(level=logot_level, logger=logot_logger):
         yield logot
-
-
-@pytest.fixture(scope="session")
-def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
-    """
-    The `capturer` used for automatic log capturing.
-    """
-    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 @pytest.fixture(scope="session")
@@ -83,6 +75,14 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
     The `logger` used for automatic log capturing.
     """
     return _get_option(request, name="logger", parser=str, default=Logot.DEFAULT_LOGGER)
+
+
+@pytest.fixture(scope="session")
+def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
+    """
+    The `capturer` used for automatic log capturing.
+    """
+    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 @pytest.fixture(scope="session")

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -56,7 +56,7 @@ def logot(
     """
     An initialized `logot.Logot` instance with log capturing enabled.
     """
-    logot = Logot(timeout=logot_timeout, async_waiter=logot_async_waiter)
+    logot = Logot(capturer=logot_capturer, timeout=logot_timeout, async_waiter=logot_async_waiter)
     capturer_obj = logot_capturer()
     capturer_obj.start_capturing(logot, level=logot_level, logger=logot_logger)
     yield logot

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
         parser,
         group,
         name="capturer",
-        help="The `capturer` used for automatic log capturing.",
+        help="The default `capturer` for the `logot` fixture",
     )
     _add_option(
         parser,
@@ -80,7 +80,7 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
 @pytest.fixture(scope="session")
 def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
     """
-    The `capturer` used for automatic log capturing.
+    The default `capturer` for the `logot` fixture.
     """
     return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -28,6 +28,12 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
     _add_option(
         parser,
         group,
+        name="capturer",
+        help="The default `capturer` for the `logot` fixture",
+    )
+    _add_option(
+        parser,
+        group,
         name="timeout",
         help="The default `timeout` (in seconds) for the `logot` fixture",
     )
@@ -36,12 +42,6 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
         group,
         name="async_waiter",
         help="The default `async_waiter` for the `logot` fixture",
-    )
-    _add_option(
-        parser,
-        group,
-        name="capturer",
-        help="The default `capturer` for the `logot` fixture",
     )
 
 

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -60,7 +60,7 @@ def logot(
         timeout=logot_timeout,
         async_waiter=logot_async_waiter,
     )
-    with logot.capturing(logot_capturer, level=logot_level, logger=logot_logger) as logot:
+    with logot_capturer(logot, level=logot_level, logger=logot_logger):
         yield logot
 
 

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -57,12 +57,8 @@ def logot(
     An initialized `logot.Logot` instance with log capturing enabled.
     """
     logot = Logot(capturer=logot_capturer, timeout=logot_timeout, async_waiter=logot_async_waiter)
-    # Start automatic log capturing.
-    # Use the `Capturer` directly, rather than `Logot.capturing()`, to save a few CPU cycles.
-    capturer_obj = logot_capturer()
-    capturer_obj.start_capturing(logot, level=logot_level, logger=logot_logger)
-    yield logot
-    capturer_obj.stop_capturing()
+    with logot.capturing(level=logot_level, logger=logot_logger):
+        yield logot
 
 
 @pytest.fixture(scope="session")

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -51,17 +51,16 @@ def logot(
     logot_logger: str | None,
     logot_timeout: float,
     logot_async_waiter: Callable[[], AsyncWaiter],
-    logot_capturer: Capturer[...],
+    logot_capturer: Callable[[], Capturer],
 ) -> Generator[Logot, None, None]:
     """
     An initialized `logot.Logot` instance with log capturing enabled.
     """
-    logot = Logot(
-        timeout=logot_timeout,
-        async_waiter=logot_async_waiter,
-    )
-    with logot_capturer(logot, level=logot_level, logger=logot_logger):
-        yield logot
+    logot = Logot(timeout=logot_timeout, async_waiter=logot_async_waiter)
+    capturer_obj = logot_capturer()
+    capturer_obj.start_capturing(logot, level=logot_level, logger=logot_logger)
+    yield logot
+    capturer_obj.stop_capturing()
 
 
 @pytest.fixture(scope="session")
@@ -81,7 +80,7 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
 
 
 @pytest.fixture(scope="session")
-def logot_capturer(request: pytest.FixtureRequest) -> Capturer[...]:
+def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
     """
     The `capturer` used for automatic log capturing.
     """

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -47,11 +47,11 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
 
 @pytest.fixture()
 def logot(
+    logot_capturer: Callable[[], Capturer],
     logot_level: str | int,
     logot_logger: str | None,
     logot_timeout: float,
     logot_async_waiter: Callable[[], AsyncWaiter],
-    logot_capturer: Callable[[], Capturer],
 ) -> Generator[Logot, None, None]:
     """
     An initialized `logot.Logot` instance with log capturing enabled.
@@ -61,6 +61,14 @@ def logot(
     capturer_obj.start_capturing(logot, level=logot_level, logger=logot_logger)
     yield logot
     capturer_obj.stop_capturing()
+
+
+@pytest.fixture(scope="session")
+def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
+    """
+    The `capturer` used for automatic log capturing.
+    """
+    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 @pytest.fixture(scope="session")
@@ -77,14 +85,6 @@ def logot_logger(request: pytest.FixtureRequest) -> str | None:
     The `logger` used for automatic log capturing.
     """
     return _get_option(request, name="logger", parser=str, default=Logot.DEFAULT_LOGGER)
-
-
-@pytest.fixture(scope="session")
-def logot_capturer(request: pytest.FixtureRequest) -> Callable[[], Capturer]:
-    """
-    The `capturer` used for automatic log capturing.
-    """
-    return _get_option(request, name="capturer", parser=import_any_parsed, default=Logot.DEFAULT_CAPTURER)
 
 
 @pytest.fixture(scope="session")

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -4,11 +4,9 @@ import sys
 from typing import Any, TypeVar
 
 if sys.version_info >= (3, 10):
-    from typing import Concatenate as Concatenate
     from typing import ParamSpec as ParamSpec
     from typing import TypeAlias as TypeAlias
 else:
-    from typing_extensions import Concatenate as Concatenate
     from typing_extensions import ParamSpec as ParamSpec
     from typing_extensions import TypeAlias as TypeAlias
 

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -4,9 +4,11 @@ import sys
 from typing import Any, TypeVar
 
 if sys.version_info >= (3, 10):
+    from typing import Concatenate as Concatenate
     from typing import ParamSpec as ParamSpec
     from typing import TypeAlias as TypeAlias
 else:
+    from typing_extensions import Concatenate as Concatenate
     from typing_extensions import ParamSpec as ParamSpec
     from typing_extensions import TypeAlias as TypeAlias
 

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Callable, ClassVar
 from unittest import TestCase, TestResult
 
@@ -27,7 +26,7 @@ class LogotTestCase(TestCase):
     Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
     """
 
-    logot_logger: ClassVar[logging.Logger | str | None] = Logot.DEFAULT_LOGGER
+    logot_logger: ClassVar[str | None] = Logot.DEFAULT_LOGGER
     """
     The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
 

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, ClassVar
 from unittest import TestCase, TestResult
 
-from logot._logot import Logot
+from logot._logot import Capturer, Logot
 from logot._wait import AsyncWaiter
 
 
@@ -33,6 +33,8 @@ class LogotTestCase(TestCase):
     Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
     """
 
+    logot_capturer: ClassVar[Capturer[...]] = Logot.DEFAULT_CAPTURER
+
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """
     The default ``timeout`` (in seconds) for :attr:`LogotTestCase.logot`.
@@ -52,7 +54,7 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
-        ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
+        ctx = self.__class__.logot_capturer(self.logot, level=self.logot_level, logger=self.logot_logger)
         ctx.__enter__()
         self.addCleanup(ctx.__exit__, None, None, None)
 

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -19,6 +19,8 @@ class LogotTestCase(TestCase):
     Use this to make log assertions in your tests.
     """
 
+    logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
+
     logot_level: ClassVar[str | int] = Logot.DEFAULT_LEVEL
     """
     The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
@@ -32,8 +34,6 @@ class LogotTestCase(TestCase):
 
     Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
     """
-
-    logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """
@@ -54,9 +54,9 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
-        capturer = self.__class__.logot_capturer()
-        capturer.start_capturing(self.logot, level=self.logot_level, logger=self.logot_logger)
-        self.addCleanup(capturer.stop_capturing)
+        capturer_obj = self.__class__.logot_capturer()
+        capturer_obj.start_capturing(self.logot, level=self.logot_level, logger=self.logot_logger)
+        self.addCleanup(capturer_obj.stop_capturing)
 
     def run(self, result: TestResult | None = None) -> TestResult | None:
         self._logot_setup()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -55,11 +55,8 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
-        # Start automatic log capturing.
-        # Use the `Capturer` directly, rather than `Logot.capturing()`, to save a few CPU cycles.
-        capturer_obj = self.__class__.logot_capturer()
-        capturer_obj.start_capturing(self.logot, level=self.logot_level, logger=self.logot_logger)
-        self.addCleanup(capturer_obj.stop_capturing)
+        ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
+        self.addCleanup(ctx.__exit__, None, None, None)
 
     def run(self, result: TestResult | None = None) -> TestResult | None:
         self._logot_setup()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -33,7 +33,7 @@ class LogotTestCase(TestCase):
     Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
     """
 
-    logot_capturer: ClassVar[Capturer[...]] = Logot.DEFAULT_CAPTURER
+    logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """
@@ -54,9 +54,9 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
-        ctx = self.__class__.logot_capturer(self.logot, level=self.logot_level, logger=self.logot_logger)
-        ctx.__enter__()
-        self.addCleanup(ctx.__exit__, None, None, None)
+        capturer = self.__class__.logot_capturer()
+        capturer.start_capturing(self.logot, level=self.logot_level, logger=self.logot_logger)
+        self.addCleanup(capturer.stop_capturing)
 
     def run(self, result: TestResult | None = None) -> TestResult | None:
         self._logot_setup()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -34,6 +34,11 @@ class LogotTestCase(TestCase):
     """
 
     logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
+    """
+    The default ``capturer`` for :attr:`LogotTestCase.logot`.
+
+    Defaults to :attr:`logot.Logot.DEFAULT_CAPTURER`.
+    """
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -55,6 +55,8 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
+        # Start automatic log capturing.
+        # Use the `Capturer` directly, rather than `Logot.capturing()`, to save a few CPU cycles.
         capturer_obj = self.__class__.logot_capturer()
         capturer_obj.start_capturing(self.logot, level=self.logot_level, logger=self.logot_logger)
         self.addCleanup(capturer_obj.stop_capturing)

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -19,8 +19,6 @@ class LogotTestCase(TestCase):
     Use this to make log assertions in your tests.
     """
 
-    logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
-
     logot_level: ClassVar[str | int] = Logot.DEFAULT_LEVEL
     """
     The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
@@ -34,6 +32,8 @@ class LogotTestCase(TestCase):
 
     Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
     """
+
+    logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
 
     logot_timeout: ClassVar[float] = Logot.DEFAULT_TIMEOUT
     """

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -51,6 +51,7 @@ class LogotTestCase(TestCase):
 
     def _logot_setup(self) -> None:
         self.logot = Logot(
+            capturer=self.__class__.logot_capturer,
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -55,6 +55,7 @@ class LogotTestCase(TestCase):
             timeout=self.__class__.logot_timeout,
             async_waiter=self.__class__.logot_async_waiter,
         )
+        # TODO: Use `TestCase.enterContext()` when we only need to support Python 3.11+.
         ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
         ctx.__enter__()
         self.addCleanup(ctx.__exit__, None, None, None)

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -56,6 +56,7 @@ class LogotTestCase(TestCase):
             async_waiter=self.__class__.logot_async_waiter,
         )
         ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
+        ctx.__enter__()
         self.addCleanup(ctx.__exit__, None, None, None)
 
     def run(self, result: TestResult | None = None) -> TestResult | None:

--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 
 def validate_level(level: str | int) -> str | int:
     # Handle `str` or `int` level.
@@ -11,12 +9,9 @@ def validate_level(level: str | int) -> str | int:
     raise TypeError(f"Invalid level: {level!r}")
 
 
-def validate_logger(logger: logging.Logger | str | None) -> logging.Logger:
+def validate_logger(logger: str | None) -> str | None:
     # Handle `None` or `str` logger.
     if logger is None or isinstance(logger, str):
-        return logging.getLogger(logger)
-    # Handle `Logger` logger.
-    if isinstance(logger, logging.Logger):
         return logger
     # Handle invalid logger.
     raise TypeError(f"Invalid logger: {logger!r}")

--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -9,6 +9,14 @@ def validate_level(level: str | int) -> str | int:
     raise TypeError(f"Invalid level: {level!r}")
 
 
+def validate_logger(logger: str | None) -> str | None:
+    # Handle `None` or `str` logger.
+    if logger is None or isinstance(logger, str):
+        return logger
+    # Handle invalid logger.
+    raise TypeError(f"Invalid logger: {logger!r}")
+
+
 def validate_timeout(timeout: float) -> float:
     # Handle numeric timeout.
     if isinstance(timeout, (float, int)):

--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -9,14 +9,6 @@ def validate_level(level: str | int) -> str | int:
     raise TypeError(f"Invalid level: {level!r}")
 
 
-def validate_logger(logger: str | None) -> str | None:
-    # Handle `None` or `str` logger.
-    if logger is None or isinstance(logger, str):
-        return logger
-    # Handle invalid logger.
-    raise TypeError(f"Invalid logger: {logger!r}")
-
-
 def validate_timeout(timeout: float) -> float:
     # Handle numeric timeout.
     if isinstance(timeout, (float, int)):

--- a/logot/logging.py
+++ b/logot/logging.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from logot._logging import capture_logging as capture_logging
+from logot._logging import LoggingCapturer as LoggingCapturer

--- a/logot/logging.py
+++ b/logot/logging.py
@@ -1,3 +1,10 @@
+"""
+Integration API for :mod:`logging`.
+
+.. seealso::
+
+    See :ref:`log-capturing-logging` usage guide.
+"""
 from __future__ import annotations
 
 from logot._logging import LoggingCapturer as LoggingCapturer

--- a/logot/logging.py
+++ b/logot/logging.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from logot._logging import capture_logging
+from logot._logging import capture_logging as capture_logging

--- a/logot/logging.py
+++ b/logot/logging.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+from logot._logging import capture_logging

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -15,7 +15,7 @@ def test_format_level_int() -> None:
     assert format_level(20) == "Level 20"
 
 
-def test_validate_logger_type_fail() -> None:
+def test_format_level_type_fail() -> None:
     with pytest.raises(TypeError) as ex:
         format_level(cast(str, 1.5))
     assert str(ex.value) == "Invalid level: 1.5"

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 from logot import Captured, Logged, logged
 from tests import lines
 
@@ -56,9 +54,9 @@ def test_record_logged_reduce() -> None:
     )
     # Test `int` level.
     assert_reduce(
-        logged.log(logging.INFO, "foo bar"),
+        logged.log(20, "foo bar"),
         Captured("INFO", "foo bar"),  # Non-matching (needs levelno).
-        Captured("INFO", "foo bar", levelno=logging.INFO),  # Matching.
+        Captured("INFO", "foo bar", levelno=20),  # Matching.
     )
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+from logot import Logot, logged
+from tests import logger
+
+
+def test_capturing() -> None:
+    assert logger.level == logging.NOTSET
+    # Set a fairly non-verbose log level.
+    logger.setLevel(logging.WARNING)
+    try:
+        with Logot().capturing(level="DEBUG", logger="logot") as logot:
+            # The logger will have been overridden for the required verbosity.
+            assert logger.level == logging.DEBUG
+            # Write a log.
+            logger.info("foo bar")
+            # Assert the log was captured.
+            logot.assert_logged(logged.info("foo bar"))
+        # When the capture ends, the logging verbosity is restored.
+        assert logger.level == logging.WARNING
+    finally:
+        # Whatever this test does, reset the logger to what it was!
+        logger.setLevel(logging.NOTSET)

--- a/tests/test_logot.py
+++ b/tests/test_logot.py
@@ -1,30 +1,9 @@
 from __future__ import annotations
 
-import logging
-
 import pytest
 
 from logot import Captured, Logot, logged
-from tests import lines, logger
-
-
-def test_capturing() -> None:
-    assert logger.level == logging.NOTSET
-    # Set a fairly non-verbose log level.
-    logger.setLevel(logging.WARNING)
-    try:
-        with Logot().capturing(level="DEBUG", logger="logot") as logot:
-            # The logger will have been overridden for the required verbosity.
-            assert logger.level == logging.DEBUG
-            # Write a log.
-            logger.info("foo bar")
-            # Assert the log was captured.
-            logot.assert_logged(logged.info("foo bar"))
-        # When the capture ends, the logging verbosity is restored.
-        assert logger.level == logging.WARNING
-    finally:
-        # Whatever this test does, reset the logger to what it was!
-        logger.setLevel(logging.NOTSET)
+from tests import lines
 
 
 def test_assert_logged_pass(logot: Logot) -> None:

--- a/tests/test_logot.py
+++ b/tests/test_logot.py
@@ -13,7 +13,7 @@ def test_capturing() -> None:
     # Set a fairly non-verbose log level.
     logger.setLevel(logging.WARNING)
     try:
-        with Logot().capturing(level=logging.DEBUG, logger=logger) as logot:
+        with Logot().capturing(level="DEBUG", logger="logot") as logot:
             # The logger will have been overridden for the required verbosity.
             assert logger.level == logging.DEBUG
             # Write a log.

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -6,11 +6,12 @@ from typing import Any, Callable
 
 import pytest
 
-from logot import Logot
+from logot import Capturer, Logot
 from logot._pytest import get_optname, get_qualname
 from logot._typing import MISSING
 from logot._wait import AsyncWaiter
 from logot.asyncio import AsyncioWaiter
+from logot.logging import LoggingCapturer
 
 EXPECTED_VAR: ContextVar[Any] = ContextVar(f"{__name__}.EXPECTED_VAR")
 
@@ -69,6 +70,18 @@ def test_logger_default(logot_logger: str | int) -> None:
 
 def test_logger_config_pass(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "logger", "logot")
+
+
+def test_capturer_default(logot_capturer: Callable[[], Capturer]) -> None:
+    assert logot_capturer is Logot.DEFAULT_CAPTURER
+
+
+def test_capturer_config_pass(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "capturer", "logot.logging.LoggingCapturer", expected=LoggingCapturer)
+
+
+def test_capturer_config_fail(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "capturer", "boom!", passed=False)
 
 
 def test_timeout_default(logot_timeout: float) -> None:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import logging
 from typing import cast
 
 import pytest
 
 from logot._validate import validate_level, validate_logger, validate_timeout
-from tests import logger
 
 
 def test_validate_level_str_pass() -> None:
@@ -24,15 +22,11 @@ def test_validate_level_type_fail() -> None:
 
 
 def test_validate_logger_none_pass() -> None:
-    assert validate_logger(None) is logging.getLogger()
+    assert validate_logger(None) is None
 
 
 def test_validate_logger_str_pass() -> None:
-    assert validate_logger("logot") is logger
-
-
-def test_validate_logger_logger_pass() -> None:
-    assert validate_logger(logging.getLogger("logot")) is logger
+    assert validate_logger("logot") == "logot"
 
 
 def test_validate_logger_type_fail() -> None:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pytest
 
-from logot._validate import validate_level, validate_logger, validate_timeout
+from logot._validate import validate_level, validate_timeout
 
 
 def test_validate_level_str_pass() -> None:
@@ -19,20 +19,6 @@ def test_validate_level_type_fail() -> None:
     with pytest.raises(TypeError) as ex:
         validate_level(cast(int, 1.5))
     assert str(ex.value) == "Invalid level: 1.5"
-
-
-def test_validate_logger_none_pass() -> None:
-    assert validate_logger(None) is None
-
-
-def test_validate_logger_str_pass() -> None:
-    assert validate_logger("logot") == "logot"
-
-
-def test_validate_logger_type_fail() -> None:
-    with pytest.raises(TypeError) as ex:
-        validate_logger(cast(str, 1.5))
-    assert str(ex.value) == "Invalid logger: 1.5"
 
 
 def test_validate_timeout_numeric_pass() -> None:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pytest
 
-from logot._validate import validate_level, validate_timeout
+from logot._validate import validate_level, validate_logger, validate_timeout
 
 
 def test_validate_level_str_pass() -> None:
@@ -19,6 +19,20 @@ def test_validate_level_type_fail() -> None:
     with pytest.raises(TypeError) as ex:
         validate_level(cast(int, 1.5))
     assert str(ex.value) == "Invalid level: 1.5"
+
+
+def test_validate_logger_none_pass() -> None:
+    assert validate_logger(None) is None
+
+
+def test_validate_logger_str_pass() -> None:
+    assert validate_logger("logot") == "logot"
+
+
+def test_validate_logger_type_fail() -> None:
+    with pytest.raises(TypeError) as ex:
+        validate_logger(cast(str, 1.5))
+    assert str(ex.value) == "Invalid logger: 1.5"
 
 
 def test_validate_timeout_numeric_pass() -> None:


### PR DESCRIPTION
- Added abstract `Capturer` class.
- Removed `logging.Logger` type from all logger types, to fully break the eager importing of `logging`.

Refs #28 
Closes #82