### PR TITLE
Renaming `logger` to `name` for `Logot.capturing()`

### DIFF
--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -29,11 +29,11 @@ Configuring
 -----------
 
 The :meth:`Logot.capturing` method defaults to capturing **all** records from the root logger. Customize this with the
-``level`` and ``logger`` arguments to :meth:`Logot.capturing`:
+``level`` and ``name`` arguments to :meth:`Logot.capturing`:
 
 .. code:: python
 
-   with Logot().capturing(level=logging.WARNING, logger="app") as logot:
+   with Logot().capturing(level=logging.WARNING, name="app") as logot:
       do_something()
       logot.assert_logged(logged.info("App started"))
 

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -42,10 +42,10 @@ Use the following CLI and :external+pytest:doc:`configuration <reference/customi
 
    Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
 
-``--logot-logger``, ``logot_logger``
-   The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
+``--logot-name``, ``logot_name``
+   The ``name`` used for automatic :doc:`log capturing </log-capturing>`.
 
-   Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
+   Defaults to :attr:`logot.Logot.DEFAULT_NAME`.
 
 ``--logot-capturer``, ``logot_capturer``
    The default ``capturer`` for the ``logot`` fixture.
@@ -79,8 +79,8 @@ The following fixtures are available in the :mod:`pytest` plugin:
 ``logot_level:`` :class:`str` | :class:`int`
    The ``level`` used for automatic :doc:`log capturing </log-capturing>`.
 
-``logot_logger:`` :class:`str` | :data:`None`
-   The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
+``logot_name:`` :class:`str` | :data:`None`
+   The ``name`` used for automatic :doc:`log capturing </log-capturing>`.
 
 ``logot_capturer:`` ``Callable`` [[], :class:`Capturer` ]
    The default ``capturer`` for the ``logot`` fixture.

--- a/docs/using-unittest.rst
+++ b/docs/using-unittest.rst
@@ -30,7 +30,7 @@ Override ``logot``-prefixed attributes in your test case to configure the
 
    class MyAppTest(LogotTestCase):
       logot_level = "WARNING"
-      logot_logger = "app"
+      logot_name = "app"
       logot_timeout = 10.0
 
 .. seealso::

--- a/logot/_logging.py
+++ b/logot/_logging.py
@@ -4,7 +4,7 @@ import logging
 
 from logot._capture import Captured
 from logot._logot import Capturer, Logot
-from logot._typing import Level, Logger
+from logot._typing import Level, Name
 
 
 class LoggingCapturer(Capturer):
@@ -18,8 +18,8 @@ class LoggingCapturer(Capturer):
 
     __slots__ = ("_logger", "_handler", "_prev_levelno")
 
-    def start_capturing(self, logot: Logot, /, *, level: Level, logger: Logger) -> None:
-        logger = self._logger = logging.getLogger(logger)
+    def start_capturing(self, logot: Logot, /, *, level: Level, name: Name) -> None:
+        logger = self._logger = logging.getLogger(name)
         handler = self._handler = _Handler(level, logot)
         # If the logger is less verbose than the handler, force it to the necessary verboseness.
         self._prev_levelno = logger.level

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -110,8 +110,8 @@ class Logot:
         """
         Captures logs emitted at the given ``level`` by the given logger ``name`` for the duration of the context.
 
-        If the named logger's level is less verbose than the requested ``level``, it will be temporarily adjusted to
-        the requested ``level`` for the duration of the context.
+        If the named logger level is less verbose than the requested ``level``, it will be temporarily adjusted to the
+        requested ``level`` for the duration of the context.
 
         .. seealso::
 

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -108,7 +108,8 @@ class Logot:
         capturer: Callable[[], Capturer] | None = None,
     ) -> AbstractContextManager[Logot]:
         """
-        Captures logs emitted at the given ``level`` by the given logger ``name`` for the duration of the context.
+        Captures logs emitted at the given ``level`` (or higher) by the given logger ``name`` for the duration of the
+        context.
 
         If the named logger level is less verbose than the requested ``level``, it will be temporarily adjusted to the
         requested ``level`` for the duration of the context.

--- a/logot/_logot.py
+++ b/logot/_logot.py
@@ -10,8 +10,8 @@ from typing import Any, Callable, ClassVar, Generic
 from logot._capture import Captured
 from logot._import import LazyCallable
 from logot._logged import Logged
-from logot._typing import Level, Logger
-from logot._validate import validate_level, validate_logger, validate_timeout
+from logot._typing import Level, Name
+from logot._validate import validate_level, validate_name, validate_timeout
 from logot._wait import AsyncWaiter, W, create_threading_waiter
 
 
@@ -35,11 +35,11 @@ class Logot:
     The default ``level`` used by :meth:`capturing`.
     """
 
-    DEFAULT_LOGGER: ClassVar[Logger] = None
+    DEFAULT_NAME: ClassVar[Name] = None
     """
-    The default ``logger`` used by :meth:`capturing`.
+    The default ``name`` used by :meth:`capturing`.
 
-    This is the root logger.
+    Defaults to :data:`None`, representing the root logger.
     """
 
     DEFAULT_CAPTURER: ClassVar[Callable[[], Capturer]] = LazyCallable("logot.logging", "LoggingCapturer")
@@ -104,13 +104,13 @@ class Logot:
         self,
         *,
         level: Level = DEFAULT_LEVEL,
-        logger: Logger = DEFAULT_LOGGER,
+        name: Name = DEFAULT_NAME,
         capturer: Callable[[], Capturer] | None = None,
     ) -> AbstractContextManager[Logot]:
         """
-        Captures logs emitted at the given ``level`` by the given ``logger`` for the duration of the context.
+        Captures logs emitted at the given ``level`` by the given logger ``name`` for the duration of the context.
 
-        If the given ``logger`` level is less verbose than the requested ``level``, it will be temporarily adjusted to
+        If the named logger's level is less verbose than the requested ``level``, it will be temporarily adjusted to
         the requested ``level`` for the duration of the context.
 
         .. seealso::
@@ -119,7 +119,7 @@ class Logot:
 
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`). Defaults to
             :attr:`Logot.DEFAULT_LEVEL`.
-        :param logger: A logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_LOGGER`.
+        :param name: A logger name to capture logs from. Defaults to :attr:`Logot.DEFAULT_NAME`.
         :param capturer: Protocol used to capture logs. This is for integration with
             :ref:`3rd-party logging frameworks <integrations-logging>`. Defaults to :attr:`Logot.capturer`.
         """
@@ -127,8 +127,8 @@ class Logot:
             capturer = self.capturer
         capturer_obj = capturer()
         level = validate_level(level)
-        logger = validate_logger(logger)
-        return _Capturing(self, capturer_obj, level=level, logger=logger)
+        name = validate_name(name)
+        return _Capturing(self, capturer_obj, level=level, name=name)
 
     def capture(self, captured: Captured) -> None:
         """
@@ -289,7 +289,7 @@ class Capturer(ABC):
     __slots__ = ()
 
     @abstractmethod
-    def start_capturing(self, logot: Logot, /, *, level: Level, logger: Logger) -> None:
+    def start_capturing(self, logot: Logot, /, *, level: Level, name: Name) -> None:
         """
         Starts capturing logs for the given :class:`Logot`.
 
@@ -297,7 +297,7 @@ class Capturer(ABC):
 
         :param logot: The :class:`Logot` instance.
         :param level: A log level name (e.g. ``"DEBUG"``) or numeric level (e.g. :data:`logging.DEBUG`).
-        :param logger: A logger name to capture logs from.
+        :param name: A logger name to capture logs from.
         """
         raise NotImplementedError
 
@@ -310,16 +310,16 @@ class Capturer(ABC):
 
 
 class _Capturing:
-    __slots__ = ("_logot", "_capturer_obj", "_level", "_logger")
+    __slots__ = ("_logot", "_capturer_obj", "_level", "_name")
 
-    def __init__(self, logot: Logot, capturer: Capturer, *, level: Level, logger: Logger) -> None:
+    def __init__(self, logot: Logot, capturer: Capturer, *, level: Level, name: Name) -> None:
         self._logot = logot
         self._capturer_obj = capturer
         self._level = level
-        self._logger = logger
+        self._name = name
 
     def __enter__(self) -> Logot:
-        self._capturer_obj.start_capturing(self._logot, level=self._level, logger=self._logger)
+        self._capturer_obj.start_capturing(self._logot, level=self._level, name=self._name)
         return self._logot
 
     def __exit__(

--- a/logot/_loguru.py
+++ b/logot/_loguru.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from functools import partial
 
 import loguru
+from loguru import logger
 
 from logot._capture import Captured
 from logot._logot import Capturer, Logot
-from logot._typing import Level, Logger
+from logot._typing import Level, Name
 
 
 class LoguruCapturer(Capturer):
@@ -16,11 +17,11 @@ class LoguruCapturer(Capturer):
 
     __slots__ = ("_handler_id",)
 
-    def start_capturing(self, logot: Logot, /, *, level: Level, logger: Logger) -> None:
-        self._handler_id = loguru.logger.add(partial(_sink, logot=logot), level=level, filter=logger)
+    def start_capturing(self, logot: Logot, /, *, level: Level, name: Name) -> None:
+        self._handler_id = logger.add(partial(_sink, logot=logot), level=level, filter=name)
 
     def stop_capturing(self) -> None:
-        loguru.logger.remove(self._handler_id)
+        logger.remove(self._handler_id)
 
 
 def _sink(msg: loguru.Message, *, logot: Logot) -> None:

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -7,7 +7,7 @@ import pytest
 
 from logot._import import import_any_parsed
 from logot._logot import Capturer, Logot
-from logot._typing import MISSING, Level, Logger, T
+from logot._typing import MISSING, Level, Name, T
 from logot._wait import AsyncWaiter
 
 
@@ -22,8 +22,8 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
     _add_option(
         parser,
         group,
-        name="logger",
-        help="The `logger` used for automatic `logot` log capturing",
+        name="name",
+        help="The `name` used for automatic `logot` log capturing",
     )
     _add_option(
         parser,
@@ -48,7 +48,7 @@ def pytest_addoption(parser: pytest.Parser, pluginmanager: pytest.PytestPluginMa
 @pytest.fixture()
 def logot(
     logot_level: Level,
-    logot_logger: Logger,
+    logot_name: Name,
     logot_capturer: Callable[[], Capturer],
     logot_timeout: float,
     logot_async_waiter: Callable[[], AsyncWaiter],
@@ -57,7 +57,7 @@ def logot(
     An initialized `logot.Logot` instance with log capturing enabled.
     """
     logot = Logot(capturer=logot_capturer, timeout=logot_timeout, async_waiter=logot_async_waiter)
-    with logot.capturing(level=logot_level, logger=logot_logger):
+    with logot.capturing(level=logot_level, name=logot_name):
         yield logot
 
 
@@ -70,11 +70,11 @@ def logot_level(request: pytest.FixtureRequest) -> Level:
 
 
 @pytest.fixture(scope="session")
-def logot_logger(request: pytest.FixtureRequest) -> Logger:
+def logot_name(request: pytest.FixtureRequest) -> Name:
     """
-    The `logger` used for automatic log capturing.
+    The `name` used for automatic log capturing.
     """
-    return _get_option(request, name="logger", parser=str, default=Logot.DEFAULT_LOGGER)
+    return _get_option(request, name="name", parser=str, default=Logot.DEFAULT_NAME)
 
 
 @pytest.fixture(scope="session")

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -15,6 +15,6 @@ T = TypeVar("T")
 
 # TODO: Use `UnionType` when we only need to support Python 3.10+.
 Level: TypeAlias = Union[str, int]
-Logger: TypeAlias = Union[str, None]
+Name: TypeAlias = Union[str, None]
 
 MISSING: Any = object()

--- a/logot/_unittest.py
+++ b/logot/_unittest.py
@@ -4,7 +4,7 @@ from typing import Callable, ClassVar
 from unittest import TestCase, TestResult
 
 from logot._logot import Capturer, Logot
-from logot._typing import Level, Logger
+from logot._typing import Level, Name
 from logot._wait import AsyncWaiter
 
 
@@ -27,11 +27,11 @@ class LogotTestCase(TestCase):
     Defaults to :attr:`logot.Logot.DEFAULT_LEVEL`.
     """
 
-    logot_logger: ClassVar[Logger] = Logot.DEFAULT_LOGGER
+    logot_name: ClassVar[Name] = Logot.DEFAULT_NAME
     """
-    The ``logger`` used for automatic :doc:`log capturing </log-capturing>`.
+    The ``name`` used for automatic :doc:`log capturing </log-capturing>`.
 
-    Defaults to :attr:`logot.Logot.DEFAULT_LOGGER`.
+    Defaults to :attr:`logot.Logot.DEFAULT_NAME`.
     """
 
     logot_capturer: ClassVar[Callable[[], Capturer]] = Logot.DEFAULT_CAPTURER
@@ -62,7 +62,7 @@ class LogotTestCase(TestCase):
             async_waiter=self.__class__.logot_async_waiter,
         )
         # TODO: Use `TestCase.enterContext()` when we only need to support Python 3.11+.
-        ctx = self.logot.capturing(level=self.logot_level, logger=self.logot_logger)
+        ctx = self.logot.capturing(level=self.logot_level, name=self.logot_name)
         ctx.__enter__()
         self.addCleanup(ctx.__exit__, None, None, None)
 

--- a/logot/_validate.py
+++ b/logot/_validate.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from logot._typing import Level, Logger
+from logot._typing import Level, Name
 
 
 def validate_level(level: Level) -> Level:
@@ -11,12 +11,12 @@ def validate_level(level: Level) -> Level:
     raise TypeError(f"Invalid level: {level!r}")
 
 
-def validate_logger(logger: Logger) -> Logger:
-    # Handle `None` or `str` logger.
-    if logger is None or isinstance(logger, str):
-        return logger
-    # Handle invalid logger.
-    raise TypeError(f"Invalid logger: {logger!r}")
+def validate_name(name: Name) -> Name:
+    # Handle `None` or `str` name.
+    if name is None or isinstance(name, str):
+        return name
+    # Handle invalid name.
+    raise TypeError(f"Invalid name: {name!r}")
 
 
 def validate_timeout(timeout: float) -> float:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -33,7 +33,7 @@ def test_capturing_level_reset() -> None:
     assert logger.level == logging.NOTSET
     # Set a fairly non-verbose log level.
     try:
-        with Logot().capturing(level=logging.INFO, logger="tests"):
+        with Logot().capturing(level=logging.INFO, name="tests"):
             # The logger will have been overridden for the required verbosity.
             assert logger.level == logging.INFO
         # When the capture ends, the logging verbosity is restored.
@@ -43,14 +43,14 @@ def test_capturing_level_reset() -> None:
         logger.setLevel(logging.NOTSET)
 
 
-def test_capturing_logger_pass() -> None:
-    with Logot().capturing(logger="tests") as logot:
+def test_capturing_name_pass() -> None:
+    with Logot().capturing(name="tests") as logot:
         logger.info("foo bar")
         logot.assert_logged(logged.info("foo bar"))
 
 
-def test_capturing_logger_fail() -> None:
-    with Logot().capturing(logger="boom") as logot:
+def test_capturing_name_fail() -> None:
+    with Logot().capturing(name="boom") as logot:
         logger.info("foo bar")
         logot.assert_not_logged(logged.info("foo bar"))
 

--- a/tests/test_loguru.py
+++ b/tests/test_loguru.py
@@ -36,14 +36,14 @@ def test_capturing_level_fail() -> None:
         logot.assert_not_logged(logged.debug("foo bar"))
 
 
-def test_capturing_logger_pass() -> None:
-    with Logot(capturer=LoguruCapturer).capturing(logger="tests") as logot:
+def test_capturing_name_pass() -> None:
+    with Logot(capturer=LoguruCapturer).capturing(name="tests") as logot:
         logger.info("foo bar")
         logot.assert_logged(logged.info("foo bar"))
 
 
-def test_capturing_logger_fail() -> None:
-    with Logot(capturer=LoguruCapturer).capturing(logger="boom") as logot:
+def test_capturing_name_fail() -> None:
+    with Logot(capturer=LoguruCapturer).capturing(name="boom") as logot:
         logger.info("foo bar")
         logot.assert_not_logged(logged.info("foo bar"))
 

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -8,7 +8,7 @@ import pytest
 
 from logot import Capturer, Logot
 from logot._pytest import get_optname, get_qualname
-from logot._typing import MISSING, Level, Logger
+from logot._typing import MISSING, Level, Name
 from logot._wait import AsyncWaiter
 from logot.asyncio import AsyncioWaiter
 from logot.logging import LoggingCapturer
@@ -64,12 +64,12 @@ def test_level_config_pass(pytester: pytest.Pytester) -> None:
     assert_fixture_config(pytester, "level", "INFO")
 
 
-def test_logger_default(logot_logger: Logger) -> None:
-    assert logot_logger == Logot.DEFAULT_LOGGER
+def test_name_default(logot_name: Name) -> None:
+    assert logot_name == Logot.DEFAULT_NAME
 
 
-def test_logger_config_pass(pytester: pytest.Pytester) -> None:
-    assert_fixture_config(pytester, "logger", "logot")
+def test_name_config_pass(pytester: pytest.Pytester) -> None:
+    assert_fixture_config(pytester, "name", "logot")
 
 
 def test_capturer_default(logot_capturer: Callable[[], Capturer]) -> None:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import pytest
 
-from logot._validate import validate_level, validate_logger, validate_timeout
+from logot._validate import validate_level, validate_name, validate_timeout
 
 
 def test_validate_level_str_pass() -> None:
@@ -21,18 +21,18 @@ def test_validate_level_type_fail() -> None:
     assert str(ex.value) == "Invalid level: 1.5"
 
 
-def test_validate_logger_none_pass() -> None:
-    assert validate_logger(None) is None
+def test_validate_name_none_pass() -> None:
+    assert validate_name(None) is None
 
 
-def test_validate_logger_str_pass() -> None:
-    assert validate_logger("logot") == "logot"
+def test_validate_name_str_pass() -> None:
+    assert validate_name("logot") == "logot"
 
 
-def test_validate_logger_type_fail() -> None:
+def test_validate_name_type_fail() -> None:
     with pytest.raises(TypeError) as ex:
-        validate_logger(cast(str, 1.5))
-    assert str(ex.value) == "Invalid logger: 1.5"
+        validate_name(cast(str, 1.5))
+    assert str(ex.value) == "Invalid name: 1.5"
 
 
 def test_validate_timeout_numeric_pass() -> None:


### PR DESCRIPTION
This will allow parity when matching on `LogRecord.name` (see #80). It's also more applicable to terms used in 3rd-party logging frameworks (e.g. `loguru`).