### PR TITLE
Merge all dependency groups into `dev`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     # editable mode with compatible `extra` dependencies from the test matrix. This is a compromise that allows us to
     # largely rely on the `poetry` lockfile while still testing against multiple `extra` library versions.
     - name: Install dependencies
-      run: poetry install --no-root --all-extras
+      run: poetry install --all-extras --no-root
     - name: Install lib versions
       run: pip install -e .[pytest,trio] ${{ matrix.lib-versions }}
     # Run checks.
@@ -71,7 +71,7 @@ jobs:
       uses: ./.github/actions/setup
     # Install dependencies.
     - name: Install dependencies
-      run: poetry install --all-extras --with docs
+      run: poetry install --all-extras
     # Build docs.
     - name: Build docs
       run: sphinx-build -W docs docs/_build
@@ -89,7 +89,7 @@ jobs:
       uses: ./.github/actions/setup
     # Install dependencies.
     - name: Install dependencies
-      run: poetry install --with coverage
+      run: poetry install --all-extras
     # Report coverage.
     - name: Download coverage
       uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       uses: ./.github/actions/setup
     # Install dependencies.
     - name: Install dependencies
-      run: poetry install --all-extras --only main --only docs
+      run: poetry install --all-extras --with docs
     # Build docs.
     - name: Build docs
       run: sphinx-build -W docs docs/_build
@@ -89,7 +89,7 @@ jobs:
       uses: ./.github/actions/setup
     # Install dependencies.
     - name: Install dependencies
-      run: poetry install --only coverage
+      run: poetry install --with coverage
     # Report coverage.
     - name: Download coverage
       uses: actions/download-artifact@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     - pip install poetry
     - poetry config virtualenvs.create false
     post_install:
-    - poetry install --all-extras --with docs
+    - poetry install --all-extras
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     - pip install poetry
     - poetry config virtualenvs.create false
     post_install:
-    - poetry install --all-extras --only main --only docs
+    - poetry install --all-extras --with docs
 
 sphinx:
   configuration: docs/conf.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -1120,4 +1120,4 @@ trio = ["trio"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0ca1d41b6c4e51dd9144e15b25677c70853c62008b00ba20c4a69d394f19afe7"
+content-hash = "83926575541def68f2183fac683d08ae30b8350b455fee76ba6fc13ef2bf01cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,22 +33,15 @@ loguru = ["loguru"]
 pytest = ["pytest"]
 trio = ["trio"]
 
-[tool.poetry.group.coverage.dependencies]
-coverage = "^7.4.1"
-
 [tool.poetry.group.dev.dependencies]
+coverage = "^7.4.1"
+furo = { version = "*", python = "^3.12" }
 hypothesis = "^6.96.1"
 mypy = "^1.8.0"
 ruff = "^0.1.11"
-trio-typing = "^0.10.0"
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-furo = { version = "*", python = "^3.12" }
 sphinx = { version = "7.2.6", python = "^3.12" }
 sphinx-autobuild = { version = "*", python = "^3.12" }
+trio-typing = "^0.10.0"
 
 [tool.poetry.plugins.pytest11]
 logot = "logot._pytest"


### PR DESCRIPTION
These are actually wasting time triggering uninstalls from the cached venv.

```
Installing dependencies from lock file

Package operations: 1 install, 0 updates, 4 removals

  • Removing iniconfig (2.0.0)
  • Removing loguru (0.7.2)
  • Removing pluggy (1.4.0)
  • Removing pytest (8.0.0)
  • Installing coverage (7.4.1)

Installing the current project: logot (0.4.0)
```

See https://github.com/actions/setup-python/issues/582, https://github.com/actions/setup-python/issues/505