### PR TITLE
Add note to `structlog` docs

### DIFF
--- a/docs/integrations/structlog.rst
+++ b/docs/integrations/structlog.rst
@@ -18,6 +18,12 @@ but before the final processor, as it is responsible for emitting the log event 
 more information, see the
 `structlog documentation <https://www.structlog.org/en/stable/processors.html#adapting-and-rendering>`_.
 
+.. note::
+
+   :class:`logot.structlog.StructlogCapturer` works by changing the :mod:`structlog` configuration. If you have
+   `cache_logger_on_first_use` enabled in your :func:`structlog.configure` or :func:`structlog.wrap_logger` call for
+   performance reasons, you will need to disable it during tests to enable log capturing.
+
 
 Installing
 ----------


### PR DESCRIPTION
Make it clear that the `cache_logger_on_first_use` parameter should not be set during tests.