### PR TITLE
Changed capture location for `structlog`

### DIFF
--- a/docs/integrations/structlog.rst
+++ b/docs/integrations/structlog.rst
@@ -13,10 +13,8 @@ Using with :mod:`structlog`
       do_something()
       logot.assert_logged(logged.info("App started"))
 
-:mod:`logot` preserves the preconfigured :mod:`structlog` processor chain. Events are captured at the end of the chain,
-but before the final processor, as it is responsible for emitting the log event to the underlying logging system. For
-more information, see the
-`structlog documentation <https://www.structlog.org/en/stable/processors.html#adapting-and-rendering>`_.
+:mod:`logot` will capture logs before any processors are invoked. Any filtering, formatting, or other processing from
+the processor chain will not be applied to the captured logs.
 
 .. note::
 

--- a/logot/_structlog.py
+++ b/logot/_structlog.py
@@ -28,13 +28,7 @@ class StructlogCapturer(Capturer):
         else:
             levelno = level
 
-        # We need to insert our processor before the last processor, as this is the processor that transforms the
-        # `event_dict` into the final log message. As this depends on the wrapped logger's formatting requirements,
-        # it can interfere with our capturing.
-        # See https://www.structlog.org/en/stable/processors.html#adapting-and-rendering
-        structlog.configure(
-            processors=[*processors[:-1], partial(_processor, logot=logot, name=name, levelno=levelno), processors[-1]]
-        )
+        structlog.configure(processors=[partial(_processor, logot=logot, name=name, levelno=levelno), *processors])
 
     def stop_capturing(self) -> None:
         structlog.configure(processors=self._old_processors)


### PR DESCRIPTION
Moved the capture location for `structlog` to before the processor chain, to match the behaviour seen in the `loguru` integration.