### PR TITLE
Not linking to individual 3rd-party framework integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ def test_something(logot: Logot) -> None:
     logot.assert_logged(logged.info("Something was done"))
 ```
 
-`logot` integrates with popular testing (e.g. [`pytest`](https://logot.readthedocs.io/latest/using-pytest.html), [`unittest`](https://logot.readthedocs.io/latest/using-unittest.html)), asynchronous (e.g. [`asyncio`](https://logot.readthedocs.io/latest/index.html#index-testing-threaded), [`trio`](https://logot.readthedocs.io/latest/integrations/trio.html)) and logging frameworks (e.g. [`logging`](https://logot.readthedocs.io/latest/log-capturing.html), [`loguru`](https://logot.readthedocs.io/latest/integrations/loguru.html), [`structlog`](https://logot.readthedocs.io/latest/integrations/structlog.html)). It can be extended to support many others. 💪
+`logot` integrates with popular testing ([`pytest`](https://logot.readthedocs.io/latest/using-pytest.html), [`unittest`](https://logot.readthedocs.io/latest/using-unittest.html)), asynchronous ([`asyncio`](https://logot.readthedocs.io/latest/index.html#index-testing-threaded), [3rd-party](https://logot.readthedocs.io/latest/integrations/index.html)) and logging frameworks ([`logging`](https://logot.readthedocs.io/latest/log-capturing.html), [3rd-party](https://logot.readthedocs.io/latest/integrations/index.html)). It can be extended to support many others. 💪
 
 ## Documentation 📖
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,11 +15,10 @@ Log-based testing 🪵
 
 .. note::
 
-   :mod:`logot` integrates with popular testing (e.g. :doc:`pytest </using-pytest>`,
-   :doc:`unittest </using-unittest>`), asynchronous (e.g. :ref:`asyncio <index-testing-threaded>`,
-   :doc:`trio </integrations/trio>`) and logging frameworks (e.g. :doc:`logging </log-capturing>`,
-   :doc:`loguru </integrations/loguru>`, :doc:`structlog </integrations/structlog>`). It can be extended
-   to support many others. 💪
+   :mod:`logot` integrates with popular testing (:doc:`pytest </using-pytest>`, :doc:`unittest </using-unittest>`),
+   asynchronous (:ref:`asyncio <index-testing-threaded>`, :ref:`3rd-party <integrations-async>`) and logging frameworks
+   (:doc:`logging </log-capturing>`, :ref:`3rd-party <integrations-logging>`). It can be extended to support many
+   others. 💪
 
 
 Why test logging? 🤔

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,7 +111,7 @@ Use :meth:`Logot.await_for` to pause your test until the expected logs arrive or
 
    See :doc:`/log-pattern-matching` for examples of how to wait for logs that may arrive in an unpredictable order.
 
-   See :ref:`integrations-async` for other supported asynchronous frameworks (e.g. :doc:`trio </integrations/trio>`).
+   See :ref:`integrations-async` for other supported asynchronous frameworks.
 
 
 Testing synchronous code

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -19,17 +19,11 @@ Installing package ``extras``
 -----------------------------
 
 :mod:`logot` provides package ``extras`` to ensure compatibility with supported
-:doc:`3rd-party integrations </integrations/index>`.
+:doc:`3rd-party integrations </integrations/index>`:
 
 .. code:: bash
 
-   pip install 'logot[loguru,pytest,trio]'
-
-Use the following package ``extras`` for supported 3rd-party integrations:
-
-- ``loguru`` - :doc:`/integrations/loguru`
-- ``pytest`` - :doc:`/using-pytest`
-- ``trio`` - :doc:`/integrations/trio`
+   pip install 'logot[pytest]'
 
 .. seealso::
 

--- a/docs/log-capturing.rst
+++ b/docs/log-capturing.rst
@@ -13,8 +13,7 @@ Log capturing
 
 .. seealso::
 
-   See :ref:`integrations-logging` for other supported logging frameworks (e.g. :doc:`loguru </integrations/loguru>`,
-   :doc:`structlog </integrations/structlog>`).
+   See :ref:`integrations-logging` for other supported logging frameworks.
 
 
 Test framework integrations

--- a/docs/using-pytest.rst
+++ b/docs/using-pytest.rst
@@ -37,8 +37,7 @@ using |caplog|_ as:
 - Support for :doc:`log message matching </log-message-matching>` using ``%``-style placeholders.
 - Support for :doc:`log pattern matching </log-pattern-matching>` using *log pattern operators*.
 - Support for testing :ref:`threaded <index-testing-threaded>` and :ref:`async <index-testing-async>` code.
-- Support for :ref:`3rd-party logging frameworks <integrations-logging>` (e.g. :doc:`loguru </integrations/loguru>`,
-  :doc:`structlog </integrations/structlog>`).
+- Support for :ref:`3rd-party logging frameworks <integrations-logging>`.
 - A cleaner, clearer syntax.
 
 

--- a/docs/using-unittest.rst
+++ b/docs/using-unittest.rst
@@ -43,8 +43,7 @@ testing. The above example can be rewritten using :meth:`assertLogs() <unittest.
 - Support for :doc:`log message matching </log-message-matching>` using ``%``-style placeholders.
 - Support for :doc:`log pattern matching </log-pattern-matching>` using *log pattern operators*.
 - Support for testing :ref:`threaded <index-testing-threaded>` and :ref:`async <index-testing-async>` code.
-- Support for :ref:`3rd-party logging frameworks <integrations-logging>` (e.g. :doc:`loguru </integrations/loguru>`,
-  :doc:`structlog </integrations/structlog>`).
+- Support for :ref:`3rd-party logging frameworks <integrations-logging>`.
 - A cleaner, clearer syntax.
 
 


### PR DESCRIPTION
The current approach won't scale to many 3rd-party framework integrations, and `logot` is not the arbiter of which are the "best". 😅 

This also makes it less effort to integrate new 3rd-party frameworks.