### PR TITLE
Use frozen `dataclasses` for `Logged` and `Matcher`

### DIFF
--- a/logot/_level.py
+++ b/logot/_level.py
@@ -7,7 +7,7 @@ from logot._match import Matcher
 from logot._typing import Level
 
 
-@dataclasses.dataclass(repr=False)
+@dataclasses.dataclass(repr=False, frozen=True)
 class _LevelNameMatcher(Matcher):
     __slots__ = ("levelname",)
     levelname: str
@@ -29,7 +29,7 @@ ERROR_MATCHER: Matcher = _LevelNameMatcher("ERROR")
 CRITICAL_MATCHER: Matcher = _LevelNameMatcher("CRITICAL")
 
 
-@dataclasses.dataclass(repr=False)
+@dataclasses.dataclass(repr=False, frozen=True)
 class _LevelNoMatcher(Matcher):
     __slots__ = ("levelno",)
     levelno: int

--- a/logot/_level.py
+++ b/logot/_level.py
@@ -7,7 +7,7 @@ from logot._match import Matcher
 from logot._typing import Level
 
 
-@dataclasses.dataclass(repr=False, frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class _LevelNameMatcher(Matcher):
     __slots__ = ("levelname",)
     levelname: str
@@ -29,7 +29,7 @@ ERROR_MATCHER: Matcher = _LevelNameMatcher("ERROR")
 CRITICAL_MATCHER: Matcher = _LevelNameMatcher("CRITICAL")
 
 
-@dataclasses.dataclass(repr=False, frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class _LevelNoMatcher(Matcher):
     __slots__ = ("levelno",)
     levelno: int

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -128,7 +128,7 @@ def critical(msg: str) -> Logged:
     return _MatcherLogged((CRITICAL_MATCHER, msg_matcher(msg)))
 
 
-@dataclasses.dataclass(repr=False, frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class _MatcherLogged(Logged):
     __slots__ = ("matchers",)
     matchers: tuple[Matcher, ...]
@@ -148,7 +148,7 @@ class _MatcherLogged(Logged):
         return " ".join(map(str, self.matchers))
 
 
-@dataclasses.dataclass(repr=False, frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class _ComposedLogged(Logged):
     __slots__ = ("logged_items",)
     logged_items: tuple[Logged, ...]

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -128,7 +128,7 @@ def critical(msg: str) -> Logged:
     return _MatcherLogged((CRITICAL_MATCHER, msg_matcher(msg)))
 
 
-@dataclasses.dataclass(repr=False)
+@dataclasses.dataclass(repr=False, frozen=True)
 class _MatcherLogged(Logged):
     __slots__ = ("matchers",)
     matchers: tuple[Matcher, ...]
@@ -148,14 +148,13 @@ class _MatcherLogged(Logged):
         return " ".join(map(str, self.matchers))
 
 
-@dataclasses.dataclass(init=False, repr=False)
+@dataclasses.dataclass(repr=False, frozen=True)
 class _ComposedLogged(Logged):
     __slots__ = ("logged_items",)
     logged_items: tuple[Logged, ...]
 
-    def __init__(self, logged_items: tuple[Logged, ...]) -> None:
-        assert len(logged_items) > 1
-        self.logged_items = logged_items
+    def __post_init__(self) -> None:
+        assert len(self.logged_items) > 1
 
     @classmethod
     def from_compose(cls, logged_a: Logged, logged_b: Logged) -> Logged:

--- a/logot/_msg.py
+++ b/logot/_msg.py
@@ -38,7 +38,7 @@ _CONVERSION_MAP = {
 }
 
 
-@dataclasses.dataclass(repr=False)
+@dataclasses.dataclass(repr=False, frozen=True)
 class _MessageMatcher(Matcher):
     __slots__ = ("msg",)
     msg: str

--- a/logot/_msg.py
+++ b/logot/_msg.py
@@ -38,7 +38,7 @@ _CONVERSION_MAP = {
 }
 
 
-@dataclasses.dataclass(repr=False, frozen=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class _MessageMatcher(Matcher):
     __slots__ = ("msg",)
     msg: str


### PR DESCRIPTION
This remains an internal implementation detail, but ensures no accidental mutability is introduced into `Logged`, which is documented as immutable.