### PR TITLE
Added support for wildcard messages and levels

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,8 @@ extensions = [
 
 autodoc_member_order = "bysource"
 
+autodoc_preserve_defaults = True
+
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "loguru": ("https://loguru.readthedocs.io/en/latest/", None),

--- a/docs/log-message-matching.rst
+++ b/docs/log-message-matching.rst
@@ -43,3 +43,29 @@ Placeholder  Matches
 ``%a``       Any string (non-greedy).
 ``%%``       Escape sequence, results in a ``%`` character in the result.
 ===========  ===========================================================================================================
+
+
+Wildcards
+---------
+
+The special ``...`` (ellipsis) acts as a wildcard when matching log messages.
+
+Use ``...`` to match log records with *any* message:
+
+.. code:: python
+
+   from logot import Logot, logged
+
+   def test_something(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.info(...))
+
+Or use ``...`` to match log records with *any* level:
+
+.. code:: python
+
+   from logot import Logot, logged
+
+   def test_something(logot: Logot) -> None:
+      do_something()
+      logot.assert_logged(logged.log(..., "Something %s done"))

--- a/logot/_capture.py
+++ b/logot/_capture.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
+from types import EllipsisType
 
-from logot._typing import MISSING, Name
+from logot._typing import Name
 
 
 @dataclasses.dataclass(init=False)
@@ -36,7 +37,7 @@ class Captured:
     The log message.
     """
 
-    levelno: int | None
+    levelno: int | EllipsisType | None
     """
     The log level number (e.g. :data:`logging.DEBUG`).
 
@@ -44,7 +45,7 @@ class Captured:
     :doc:`log patterns </log-pattern-matching>` from :func:`logged.log` with a numeric ``level``.
     """
 
-    name: Name
+    name: EllipsisType | Name
     """
     The logger name.
 
@@ -52,7 +53,14 @@ class Captured:
     :doc:`log patterns </log-pattern-matching>` from :func:`logged.log` with a ``name``.
     """
 
-    def __init__(self, levelname: str, msg: str, *, levelno: int = MISSING, name: str | None = MISSING) -> None:
+    def __init__(
+        self,
+        levelname: str,
+        msg: str,
+        *,
+        levelno: int | EllipsisType = ...,
+        name: str | EllipsisType | None = ...,
+    ) -> None:
         self.levelname = levelname
         self.msg = msg
         self.levelno = levelno

--- a/logot/_capture.py
+++ b/logot/_capture.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
-from types import EllipsisType
 
-from logot._typing import Name
+from logot._typing import Name, Wildcard
 
 
 @dataclasses.dataclass(init=False)
@@ -37,7 +36,7 @@ class Captured:
     The log message.
     """
 
-    levelno: int | EllipsisType | None
+    levelno: Wildcard[int | None]
     """
     The log level number (e.g. :data:`logging.DEBUG`).
 
@@ -45,7 +44,7 @@ class Captured:
     :doc:`log patterns </log-pattern-matching>` from :func:`logged.log` with a numeric ``level``.
     """
 
-    name: EllipsisType | Name
+    name: Wildcard[Name]
     """
     The logger name.
 
@@ -58,8 +57,8 @@ class Captured:
         levelname: str,
         msg: str,
         *,
-        levelno: int | EllipsisType = ...,
-        name: str | EllipsisType | None = ...,
+        levelno: Wildcard[int] = ...,
+        name: Wildcard[str | None] = ...,
     ) -> None:
         self.levelname = levelname
         self.msg = msg

--- a/logot/_level.py
+++ b/logot/_level.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
+from types import EllipsisType
 
 from logot._capture import Captured
-from logot._match import Matcher
+from logot._match import AnyMatcher, Matcher
 from logot._typing import Level
 
 
@@ -44,7 +45,10 @@ class _LevelNoMatcher(Matcher):
         return f"[Level {self.levelno}]"
 
 
-def level_matcher(level: Level) -> Matcher:
+def level_matcher(level: Level | EllipsisType) -> Matcher:
+    # Handle wildcard level.
+    if level is ...:
+        return AnyMatcher(msg="[...]")
     # Handle `str` level.
     if isinstance(level, str):
         return _LevelNameMatcher(level)

--- a/logot/_level.py
+++ b/logot/_level.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
-from types import EllipsisType
 
 from logot._capture import Captured
 from logot._match import AnyMatcher, Matcher
-from logot._typing import Level
+from logot._typing import Level, Wildcard
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
@@ -45,7 +44,7 @@ class _LevelNoMatcher(Matcher):
         return f"[Level {self.levelno}]"
 
 
-def level_matcher(level: Level | EllipsisType) -> Matcher:
+def level_matcher(level: Wildcard[Level]) -> Matcher:
     # Handle wildcard level.
     if level is ...:
         return AnyMatcher(msg="[...]")

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
+from types import EllipsisType
 
 from logot._capture import Captured
 from logot._level import CRITICAL_MATCHER, DEBUG_MATCHER, ERROR_MATCHER, INFO_MATCHER, WARNING_MATCHER, level_matcher
 from logot._match import Matcher
 from logot._msg import msg_matcher
 from logot._name import name_matcher
-from logot._typing import MISSING, Level, Name
+from logot._typing import Level, Name
 
 
 class Logged(ABC):
@@ -68,7 +69,7 @@ class Logged(ABC):
         raise NotImplementedError
 
 
-def log(level: Level, msg: str, *, name: Name = MISSING) -> Logged:
+def log(level: Level | EllipsisType, msg: str | EllipsisType, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at the given ``level`` with the given
     ``msg``.
@@ -80,7 +81,7 @@ def log(level: Level, msg: str, *, name: Name = MISSING) -> Logged:
     return _log(level_matcher(level), msg, name=name)
 
 
-def debug(msg: str, *, name: Name = MISSING) -> Logged:
+def debug(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``DEBUG`` level with the given
     ``msg``.
@@ -91,7 +92,7 @@ def debug(msg: str, *, name: Name = MISSING) -> Logged:
     return _log(DEBUG_MATCHER, msg, name=name)
 
 
-def info(msg: str, *, name: Name = MISSING) -> Logged:
+def info(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``INFO`` level with the given
     ``msg``.
@@ -102,7 +103,7 @@ def info(msg: str, *, name: Name = MISSING) -> Logged:
     return _log(INFO_MATCHER, msg, name=name)
 
 
-def warning(msg: str, *, name: Name = MISSING) -> Logged:
+def warning(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``WARNING`` level with the given
     ``msg``.
@@ -113,7 +114,7 @@ def warning(msg: str, *, name: Name = MISSING) -> Logged:
     return _log(WARNING_MATCHER, msg, name=name)
 
 
-def error(msg: str, *, name: Name = MISSING) -> Logged:
+def error(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``ERROR`` level with the given
     ``msg``.
@@ -124,7 +125,7 @@ def error(msg: str, *, name: Name = MISSING) -> Logged:
     return _log(ERROR_MATCHER, msg, name=name)
 
 
-def critical(msg: str, *, name: Name = MISSING) -> Logged:
+def critical(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``CRITICAL`` level with the given
     ``msg``.
@@ -135,9 +136,9 @@ def critical(msg: str, *, name: Name = MISSING) -> Logged:
     return _log(CRITICAL_MATCHER, msg, name=name)
 
 
-def _log(level_matcher: Matcher, msg: str, *, name: Name) -> _MatcherLogged:
+def _log(level_matcher: Matcher, msg: str | EllipsisType, *, name: Name | EllipsisType) -> _MatcherLogged:
     matchers = [level_matcher, msg_matcher(msg)]
-    if name is not MISSING:
+    if name is not ...:
         matchers.append(name_matcher(name))
     return _MatcherLogged((*matchers,))
 

--- a/logot/_logged.py
+++ b/logot/_logged.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
-from types import EllipsisType
 
 from logot._capture import Captured
 from logot._level import CRITICAL_MATCHER, DEBUG_MATCHER, ERROR_MATCHER, INFO_MATCHER, WARNING_MATCHER, level_matcher
 from logot._match import Matcher
 from logot._msg import msg_matcher
 from logot._name import name_matcher
-from logot._typing import Level, Name
+from logot._typing import Level, Name, Wildcard
 
 
 class Logged(ABC):
@@ -69,7 +68,7 @@ class Logged(ABC):
         raise NotImplementedError
 
 
-def log(level: Level | EllipsisType, msg: str | EllipsisType, *, name: Name | EllipsisType = ...) -> Logged:
+def log(level: Wildcard[Level], msg: Wildcard[str], *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at the given ``level`` with the given
     ``msg``.
@@ -81,7 +80,7 @@ def log(level: Level | EllipsisType, msg: str | EllipsisType, *, name: Name | El
     return _log(level_matcher(level), msg, name=name)
 
 
-def debug(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
+def debug(msg: str, *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``DEBUG`` level with the given
     ``msg``.
@@ -92,7 +91,7 @@ def debug(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     return _log(DEBUG_MATCHER, msg, name=name)
 
 
-def info(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
+def info(msg: str, *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``INFO`` level with the given
     ``msg``.
@@ -103,7 +102,7 @@ def info(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     return _log(INFO_MATCHER, msg, name=name)
 
 
-def warning(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
+def warning(msg: str, *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``WARNING`` level with the given
     ``msg``.
@@ -114,7 +113,7 @@ def warning(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     return _log(WARNING_MATCHER, msg, name=name)
 
 
-def error(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
+def error(msg: str, *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``ERROR`` level with the given
     ``msg``.
@@ -125,7 +124,7 @@ def error(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     return _log(ERROR_MATCHER, msg, name=name)
 
 
-def critical(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
+def critical(msg: str, *, name: Wildcard[Name] = ...) -> Logged:
     """
     Creates a :doc:`log pattern </log-pattern-matching>` representing a log record at ``CRITICAL`` level with the given
     ``msg``.
@@ -136,7 +135,7 @@ def critical(msg: str, *, name: Name | EllipsisType = ...) -> Logged:
     return _log(CRITICAL_MATCHER, msg, name=name)
 
 
-def _log(level_matcher: Matcher, msg: str | EllipsisType, *, name: Name | EllipsisType) -> _MatcherLogged:
+def _log(level_matcher: Matcher, msg: Wildcard[str], *, name: Wildcard[Name]) -> _MatcherLogged:
     matchers = [level_matcher, msg_matcher(msg)]
     if name is not ...:
         matchers.append(name_matcher(name))

--- a/logot/_match.py
+++ b/logot/_match.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 from abc import ABC, abstractmethod
 
 from logot._capture import Captured
@@ -18,3 +19,18 @@ class Matcher(ABC):
 
     def __str__(self) -> str:
         return f"({self!r})"
+
+
+@dataclasses.dataclass(frozen=True, repr=False)
+class AnyMatcher(Matcher):
+    __slots__ = ("msg",)
+    msg: str
+
+    def match(self, captured: Captured) -> bool:
+        return True
+
+    def __repr__(self) -> str:
+        return "..."
+
+    def __str__(self) -> str:
+        return self.msg

--- a/logot/_msg.py
+++ b/logot/_msg.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import dataclasses
 import re
-from types import EllipsisType
 
 from logot._capture import Captured
 from logot._match import AnyMatcher, Matcher
+from logot._typing import Wildcard
 
 # Regex matching a simplified conversion specifier.
 _RE_CONVERSION = re.compile(r"%(.|$)")
@@ -65,7 +65,7 @@ class _MessagePatternMatcher(_MessageMatcher):
         return self._pattern.fullmatch(captured.msg) is not None
 
 
-def msg_matcher(msg: str | EllipsisType) -> Matcher:
+def msg_matcher(msg: Wildcard[str]) -> Matcher:
     # Handle wildcard message.
     if msg is ...:
         return AnyMatcher("...")

--- a/logot/_msg.py
+++ b/logot/_msg.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from types import EllipsisType
 
 from logot._capture import Captured
-from logot._match import Matcher
+from logot._match import AnyMatcher, Matcher
 
 # Regex matching a simplified conversion specifier.
 _RE_CONVERSION = re.compile(r"%(.|$)")
@@ -64,7 +65,11 @@ class _MessagePatternMatcher(_MessageMatcher):
         return self._pattern.fullmatch(captured.msg) is not None
 
 
-def msg_matcher(msg: str) -> Matcher:
+def msg_matcher(msg: str | EllipsisType) -> Matcher:
+    # Handle wildcard message.
+    if msg is ...:
+        return AnyMatcher("...")
+    # Parse the message.
     parts: list[str] = _RE_CONVERSION.split(msg)
     parts_len = len(parts)
     # If there is more than one part, at least one conversion specifier was found and we might need a regex matcher.

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from types import EllipsisType
 from typing import Callable
 
 import pytest
 
 from logot._import import import_any_parsed
 from logot._logot import Capturer, Logot
-from logot._typing import MISSING, Level, Name, T
+from logot._typing import Level, Name, T
 from logot._wait import AsyncWaiter
 
 
@@ -111,10 +112,10 @@ def get_optname(name: str) -> str:
 
 def _add_option(parser: pytest.Parser, group: pytest.OptionGroup, *, name: str, help: str) -> None:
     qualname = get_qualname(name)
-    parser.addini(qualname, default=MISSING, help=help)
+    parser.addini(qualname, default=..., help=help)
     group.addoption(
         get_optname(name),
-        default=MISSING,
+        default=...,
         dest=qualname,
         metavar=name.upper(),
         help=help,
@@ -124,10 +125,10 @@ def _add_option(parser: pytest.Parser, group: pytest.OptionGroup, *, name: str, 
 def _get_option(request: pytest.FixtureRequest, *, name: str, parser: Callable[[str], T], default: T) -> T:
     qualname = get_qualname(name)
     # Try to get the value from the command line, followed by the config file.
-    value: str = request.config.getoption(qualname, default=MISSING)
-    if value is MISSING:
+    value: str | EllipsisType = request.config.getoption(qualname, default=...)
+    if value is ...:
         value = request.config.getini(qualname)
-        if value is MISSING:
+        if value is ...:
             # Give up and return the default.
             return default
     # Parse and return the value.

--- a/logot/_pytest.py
+++ b/logot/_pytest.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from types import EllipsisType
 from typing import Callable
 
 import pytest
 
 from logot._import import import_any_parsed
 from logot._logot import Capturer, Logot
-from logot._typing import Level, Name, T
+from logot._typing import Level, Name, T, Wildcard
 from logot._wait import AsyncWaiter
 
 
@@ -125,7 +124,7 @@ def _add_option(parser: pytest.Parser, group: pytest.OptionGroup, *, name: str, 
 def _get_option(request: pytest.FixtureRequest, *, name: str, parser: Callable[[str], T], default: T) -> T:
     qualname = get_qualname(name)
     # Try to get the value from the command line, followed by the config file.
-    value: str | EllipsisType = request.config.getoption(qualname, default=...)
+    value: Wildcard[str] = request.config.getoption(qualname, default=...)
     if value is ...:
         value = request.config.getini(qualname)
         if value is ...:

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, TypeVar, Union
+from typing import TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec as ParamSpec
@@ -16,13 +16,3 @@ T = TypeVar("T")
 # TODO: Use `UnionType` when we only need to support Python 3.10+.
 Level: TypeAlias = Union[str, int]
 Name: TypeAlias = Union[str, None]
-
-
-class _Missing:
-    __slots__ = ()
-
-    def __repr__(self) -> str:
-        return "..."
-
-
-MISSING: Any = _Missing()

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -18,4 +18,10 @@ T = TypeVar("T")
 Level: TypeAlias = Union[str, int]
 Name: TypeAlias = Union[str, None]
 
-Wildcard: TypeAlias = T | EllipsisType
+if TYPE_CHECKING:  # pragma: no cover
+    Wildcard: TypeAlias = T | EllipsisType
+else:  # pragma: no cover
+    # Hide `| EllipsisType` from the docs.
+    class Wildcard:
+        def __class_getitem__(cls, key):
+            return key

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 if sys.version_info >= (3, 10):
+    from types import EllipsisType
     from typing import ParamSpec as ParamSpec
     from typing import TypeAlias as TypeAlias
 else:
     from typing_extensions import ParamSpec as ParamSpec
     from typing_extensions import TypeAlias as TypeAlias
+
+    EllipsisType: TypeAlias = Any
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -18,9 +21,8 @@ Level: TypeAlias = Union[str, int]
 Name: TypeAlias = Union[str, None]
 
 if TYPE_CHECKING:  # pragma: no cover
-    from types import EllipsisType
-
-    Wildcard: TypeAlias = T | EllipsisType
+    # TODO: Use `UnionType` when we only need to support Python 3.10+.
+    Wildcard: TypeAlias = Union[T, Any]
 else:  # pragma: no cover
     # Hide `| EllipsisType` from the docs.
     class Wildcard:

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec as ParamSpec

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from typing import TypeVar, Union
+from types import EllipsisType
+from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec as ParamSpec
@@ -16,3 +17,5 @@ T = TypeVar("T")
 # TODO: Use `UnionType` when we only need to support Python 3.10+.
 Level: TypeAlias = Union[str, int]
 Name: TypeAlias = Union[str, None]
+
+Wildcard: TypeAlias = T | EllipsisType

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-from types import EllipsisType
 from typing import TYPE_CHECKING, TypeAlias, TypeVar, Union
 
 if sys.version_info >= (3, 10):
@@ -19,6 +18,8 @@ Level: TypeAlias = Union[str, int]
 Name: TypeAlias = Union[str, None]
 
 if TYPE_CHECKING:  # pragma: no cover
+    from types import EllipsisType
+
     Wildcard: TypeAlias = T | EllipsisType
 else:  # pragma: no cover
     # Hide `| EllipsisType` from the docs.

--- a/logot/_typing.py
+++ b/logot/_typing.py
@@ -22,7 +22,7 @@ Name: TypeAlias = Union[str, None]
 
 if TYPE_CHECKING:  # pragma: no cover
     # TODO: Use `UnionType` when we only need to support Python 3.10+.
-    Wildcard: TypeAlias = Union[T, Any]
+    Wildcard: TypeAlias = Union[T, EllipsisType]
 else:  # pragma: no cover
     # Hide `| EllipsisType` from the docs.
     class Wildcard:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logot"
-version = "1.4.0"
+version = "1.5.0"
 description = "Test whether your code is logging correctly 🪵"
 authors = [{ name = "Dave Hall", email = "dave@etianen.com" }]
 license = "MIT"

--- a/tests/test_level.py
+++ b/tests/test_level.py
@@ -9,11 +9,13 @@ from logot._typing import Level
 
 
 def test_repr() -> None:
+    assert repr(level_matcher(...)) == "..."
     assert repr(level_matcher("INFO")) == "'INFO'"
     assert repr(level_matcher(20)) == "20"
 
 
 def test_str() -> None:
+    assert str(level_matcher(...)) == "[...]"
     assert str(level_matcher("INFO")) == "[INFO]"
     assert str(level_matcher(20)) == "[Level 20]"
 

--- a/tests/test_logged.py
+++ b/tests/test_logged.py
@@ -14,6 +14,7 @@ def assert_reduce(logged: Logged | None, *captured_items: Captured) -> None:
 
 
 def test_matcher_logged_repr() -> None:
+    assert repr(logged.log(..., ...)) == "log(..., ...)"
     assert repr(logged.log(10, "foo bar")) == "log(10, 'foo bar')"
     assert repr(logged.log("DEBUG", "foo bar")) == "log('DEBUG', 'foo bar')"
     assert repr(logged.log("DEBUG", "foo bar", name="tests")) == "log('DEBUG', 'foo bar', name='tests')"
@@ -25,6 +26,7 @@ def test_matcher_logged_repr() -> None:
 
 
 def test_matcher_logged_str() -> None:
+    assert str(logged.log(..., ...)) == "[...] ..."
     assert str(logged.log(10, "foo bar")) == "[Level 10] foo bar"
     assert str(logged.log("DEBUG", "foo bar")) == "[DEBUG] foo bar"
     assert str(logged.log("DEBUG", "foo bar", name="tests")) == "[DEBUG] foo bar (name='tests')"
@@ -33,6 +35,14 @@ def test_matcher_logged_str() -> None:
     assert str(logged.warning("foo bar")) == "[WARNING] foo bar"
     assert str(logged.error("foo bar")) == "[ERROR] foo bar"
     assert str(logged.critical("foo bar")) == "[CRITICAL] foo bar"
+
+
+def test_matcher_logged_reduce_level_ellipsis() -> None:
+    assert_reduce(
+        logged.log(..., "foo bar"),
+        Captured("INFO", "boom!"),  # Non-matching.
+        Captured("INFO", "foo bar"),  # Matching.
+    )
 
 
 def test_matcher_logged_reduce_level_str() -> None:

--- a/tests/test_msg.py
+++ b/tests/test_msg.py
@@ -19,11 +19,21 @@ def assert_matches(pattern: str, *values: Any) -> None:
 
 
 def test_repr() -> None:
+    assert repr(msg_matcher(...)) == "..."
+    assert repr(msg_matcher("foo bar")) == "'foo bar'"
     assert repr(msg_matcher("foo %d bar")) == "'foo %d bar'"
 
 
 def test_str() -> None:
+    assert str(msg_matcher(...)) == "..."
+    assert str(msg_matcher("foo bar")) == "foo bar"
     assert str(msg_matcher("foo %d bar")) == "foo %d bar"
+
+
+@given(st.text())
+def test_wildcard_matches(msg: str) -> None:
+    matcher = msg_matcher(...)
+    assert matcher.match(Captured("DEBUG", msg))
 
 
 @given(st.integers())

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -8,7 +8,7 @@ import pytest
 
 from logot import Capturer, Logot
 from logot._pytest import get_optname, get_qualname
-from logot._typing import MISSING, Level, Name
+from logot._typing import Level, Name
 from logot._wait import AsyncWaiter
 from logot.asyncio import AsyncioWaiter
 from logot.logging import LoggingCapturer
@@ -21,7 +21,7 @@ def assert_fixture_config(
     name: str,
     value: Any,
     *,
-    expected: Any = MISSING,
+    expected: Any = ...,
     passed: bool = True,
 ) -> None:
     qualname = get_qualname(name)
@@ -34,7 +34,7 @@ def assert_fixture_config(
         """
     )
     # Set the expected `ContextVar`.
-    if expected is MISSING:
+    if expected is ...:
         expected = value
     expected_token = EXPECTED_VAR.set(expected)
     try:

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from logot._typing import MISSING
-
-
-def test_missing_repr() -> None:
-    assert repr(MISSING) == "..."


### PR DESCRIPTION
Closes #219

The special ``...`` (ellipsis) acts as a wildcard when matching log messages.

Use ``...`` to match log records with *any* message:

```py
from logot import Logot, logged

def test_something(logot: Logot) -> None:
   do_something()
   logot.assert_logged(logged.info(...))
```

Or use ``...`` to match log records with *any* level:

```py
from logot import Logot, logged

def test_something(logot: Logot) -> None:
    do_something()
    logot.assert_logged(logged.log(..., "Something %s done"))
```